### PR TITLE
refactor: add extract_response_data fn - simplify types

### DIFF
--- a/okex-client/src/client/error.rs
+++ b/okex-client/src/client/error.rs
@@ -1,7 +1,5 @@
 use thiserror::Error;
 
-use super::okex_response::ResponseWithoutData;
-
 #[derive(Error, Debug)]
 pub enum OkexClientError {
     #[error("OkexClientError: {0}")]
@@ -12,13 +10,4 @@ pub enum OkexClientError {
     Header(#[from] reqwest::header::InvalidHeaderValue),
     #[error("OkexClientError: {code:?} - {msg:?}")]
     UnexpectedResponse { msg: String, code: String },
-}
-
-impl From<ResponseWithoutData> for OkexClientError {
-    fn from(response: ResponseWithoutData) -> Self {
-        OkexClientError::UnexpectedResponse {
-            msg: response.msg,
-            code: response.code,
-        }
-    }
 }

--- a/okex-client/src/client/okex_response.rs
+++ b/okex-client/src/client/okex_response.rs
@@ -1,31 +1,10 @@
 use serde::Deserialize;
 
 #[derive(Deserialize, Debug)]
-#[serde(untagged)]
-pub enum OkexResponse {
-    WithData(ResponseWithData),
-    WithoutData(ResponseWithoutData),
-}
-
-#[derive(Deserialize, Debug)]
-#[serde(untagged)]
-pub enum OkexResponseData {
-    DepositAddress(DepositAddressData),
-    Transfer(TransferData),
-}
-
-/// Response struct from OKEX
-#[derive(Deserialize, Debug)]
-pub struct ResponseWithData {
+pub struct OkexResponse<T> {
     pub code: String,
     pub msg: String,
-    pub data: Vec<OkexResponseData>,
-}
-
-#[derive(Deserialize, Debug)]
-pub struct ResponseWithoutData {
-    pub code: String,
-    pub msg: String,
+    pub data: Option<Vec<T>>,
 }
 
 #[derive(Deserialize, Debug, Clone)]


### PR DESCRIPTION
I got rid of the enums in the deserialization - now the generics work and I think its pretty clean. Also 60 lines less than before