### PR TITLE
fix: delta fee for buy/sell

### DIFF
--- a/price-server/src/app/mod.rs
+++ b/price-server/src/app/mod.rs
@@ -122,7 +122,7 @@ impl PriceApp {
             .await?
             .buy_usd()
             .sats_from_cents(cents);
-        Ok(self.fee_calculator.increase_by_immediate_fee(sats))
+        Ok(self.fee_calculator.decrease_by_immediate_fee(sats))
     }
 
     #[instrument(skip_all, fields(correlation_id, amount = %cents.amount()), ret, err)]
@@ -136,7 +136,7 @@ impl PriceApp {
             .await?
             .sell_usd()
             .sats_from_cents(cents);
-        Ok(self.fee_calculator.decrease_by_immediate_fee(sats))
+        Ok(self.fee_calculator.increase_by_immediate_fee(sats))
     }
 
     #[instrument(skip_all, fields(correlation_id, amount = %cents.amount()), ret, err)]
@@ -150,7 +150,7 @@ impl PriceApp {
             .await?
             .buy_usd()
             .sats_from_cents(cents);
-        Ok(self.fee_calculator.increase_by_delayed_fee(sats))
+        Ok(self.fee_calculator.decrease_by_delayed_fee(sats))
     }
 
     #[instrument(skip_all, fields(correlation_id, amount = %cents.amount()), ret, err)]
@@ -164,7 +164,7 @@ impl PriceApp {
             .await?
             .sell_usd()
             .sats_from_cents(cents);
-        Ok(self.fee_calculator.decrease_by_delayed_fee(sats))
+        Ok(self.fee_calculator.increase_by_delayed_fee(sats))
     }
 
     #[instrument(skip_all, fields(correlation_id, ret, err))]


### PR DESCRIPTION
fix regression from recent fix:

- Buy USD should always `decrease` because buy implies a sell in exchange so price should be lower than current bid
- Sell USD should always `increase` because sell close position in exchange so price should be higher than current ask