### PR TITLE
feat: configure position_mode and position_side in constructor

### DIFF
--- a/okex-client/src/client/error.rs
+++ b/okex-client/src/client/error.rs
@@ -12,4 +12,6 @@ pub enum OkexClientError {
     UnexpectedResponse { msg: String, code: String },
     #[error("OkexClientError: {0}")]
     DecimalConversion(#[from] rust_decimal::Error),
+    #[error("OkexClientError: {code:?} - {msg:?}")]
+    PositionSide { msg: String, code: String },
 }

--- a/okex-client/src/client/mod.rs
+++ b/okex-client/src/client/mod.rs
@@ -423,7 +423,7 @@ impl OkexClient {
         pre_hash: String,
     ) -> Result<HeaderMap, OkexClientError> {
         let sign_base64 = self.sign_okex_request(pre_hash);
-        let simulation_flag = self.config.simulated as i32;
+        let simulation_flag = i32::from(self.config.simulated);
 
         let mut headers = HeaderMap::new();
         headers.insert(CONTENT_TYPE, HeaderValue::from_str("application/json")?);

--- a/okex-client/src/client/mod.rs
+++ b/okex-client/src/client/mod.rs
@@ -268,6 +268,13 @@ impl OkexClient {
         order_type: OkexOrderType,
         size: u64,
     ) -> Result<OrderId, OkexClientError> {
+        if pos_side != self.config.position_side {
+            return Err(OkexClientError::PositionSide {
+                msg: format!("Expected `net` position side, got `{}`", pos_side),
+                code: "0".to_string(),
+            });
+        }
+
         let mut body: HashMap<String, String> = HashMap::new();
         body.insert("ccy".to_string(), "BTC".to_string());
         body.insert("instId".to_string(), inst_id.to_string());
@@ -323,6 +330,13 @@ impl OkexClient {
         ccy: String,
         auto_cxl: bool,
     ) -> Result<ClosePositionData, OkexClientError> {
+        if pos_side != self.config.position_side {
+            return Err(OkexClientError::PositionSide {
+                msg: format!("Expected `net` position side, got `{}`", pos_side),
+                code: "0".to_string(),
+            });
+        }
+
         let mut body: HashMap<String, String> = HashMap::new();
         body.insert("instId".to_string(), inst_id.to_string());
         body.insert("mgnMode".to_string(), margin_mode.to_string());

--- a/okex-client/src/client/primitives.rs
+++ b/okex-client/src/client/primitives.rs
@@ -86,7 +86,7 @@ impl Display for OkexPositionMode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OkexPositionSide {
     Long,
     Short,

--- a/okex-client/src/client/primitives.rs
+++ b/okex-client/src/client/primitives.rs
@@ -72,14 +72,24 @@ impl Display for OkexMarginMode {
 }
 
 #[derive(Debug, Clone)]
-pub enum OkexPosition {
-    Long,
-    Short,
+pub enum OkexPositionMode {
+    LongShort,
+    Net,
 }
 
-#[derive(Debug, Clone)]
+impl Display for OkexPositionMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            OkexPositionMode::LongShort => write!(f, "long_short_mode"),
+            OkexPositionMode::Net => write!(f, "net_mode"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum OkexPositionSide {
-    LongShort(OkexPosition),
+    Long,
+    Short,
     Net,
 }
 
@@ -87,8 +97,8 @@ impl Display for OkexPositionSide {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match *self {
             OkexPositionSide::Net => write!(f, "net"),
-            OkexPositionSide::LongShort(OkexPosition::Long) => write!(f, "long"),
-            OkexPositionSide::LongShort(OkexPosition::Short) => write!(f, "short"),
+            OkexPositionSide::Long => write!(f, "long"),
+            OkexPositionSide::Short => write!(f, "short"),
         }
     }
 }
@@ -135,4 +145,6 @@ pub struct OkexClientConfig {
     pub passphrase: String,
     pub secret_key: String,
     pub simulated: bool,
+    pub position_mode: OkexPositionMode,
+    pub position_side: OkexPositionSide,
 }

--- a/okex-client/tests/client.rs
+++ b/okex-client/tests/client.rs
@@ -3,36 +3,45 @@ use std::env;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 
-use okex_client::{
-    OkexClient, OkexClientConfig, OkexClientError, OkexInstrumentId, OkexMarginMode, OkexOrderSide,
-    OkexOrderType, OkexPosition, OkexPositionSide, OKEX_MINIMUM_WITHDRAWAL_AMOUNT,
-    OKEX_MINIMUM_WITHDRAWAL_FEE,
-};
+use okex_client::*;
 
 fn configured_okex_client() -> OkexClient {
     let api_key = env::var("OKEX_API_KEY").expect("OKEX_API_KEY not set");
     let passphrase = env::var("OKEX_PASSPHRASE").expect("OKEX_PASS_PHRASE not set");
     let secret_key = env::var("OKEX_SECRET_KEY").expect("OKEX_SECRET_KEY not set");
     let simulated = false;
+    let position_mode = OkexPositionMode::Net;
+    let position_side = OkexPositionSide::Net;
+
     OkexClient::new(OkexClientConfig {
         api_key,
         passphrase,
         secret_key,
         simulated,
+        position_mode,
+        position_side,
     })
 }
 
-fn demo_okex_client() -> OkexClient {
-    let api_key = "1f360c35-4942-489b-a22c-3e38741de501".to_string();
-    let passphrase = "@Stablesats123".to_string();
-    let secret_key = "BD6CA6849F3A2CACA16F62E3D354D61C".to_string();
+fn demo_okex_client() -> Option<OkexClient> {
+    let api_key = env::var("OKEX_DEMO_API_KEY");
+    let passphrase = env::var("OKEX_DEMO_PASSPHRASE");
+    let secret_key = env::var("OKEX_DEMO_SECRET_KEY");
     let simulated = true;
-    OkexClient::new(OkexClientConfig {
-        api_key,
-        passphrase,
-        secret_key,
-        simulated,
-    })
+    let position_mode = OkexPositionMode::Net;
+    let position_side = OkexPositionSide::Net;
+
+    if let (Ok(api_key), Ok(passphrase), Ok(secret_key)) = (api_key, passphrase, secret_key) {
+        return Some(OkexClient::new(OkexClientConfig {
+            api_key,
+            passphrase,
+            secret_key,
+            simulated,
+            position_mode,
+            position_side,
+        }));
+    }
+    None
 }
 
 #[tokio::test]
@@ -52,6 +61,8 @@ async fn client_is_missing_header() -> anyhow::Result<()> {
         passphrase: "".to_string(),
         secret_key: "".to_string(),
         simulated: true,
+        position_mode: OkexPositionMode::Net,
+        position_side: OkexPositionSide::Net,
     });
 
     let address = client.get_funding_deposit_address().await;
@@ -67,19 +78,23 @@ async fn client_is_missing_header() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn funding_account_balance() -> anyhow::Result<()> {
-    let avail_balance = demo_okex_client().funding_account_balance().await?;
-    let balance = avail_balance.amt_in_btc;
-    let minimum_balance = dec!(0);
-    assert!(balance >= minimum_balance);
+    if let Some(client) = demo_okex_client() {
+        let avail_balance = client.funding_account_balance().await?;
+        let balance = avail_balance.amt_in_btc;
+        let minimum_balance = dec!(0);
+        assert!(balance >= minimum_balance);
+    }
 
     Ok(())
 }
 
 #[tokio::test]
 async fn trading_account_balance() -> anyhow::Result<()> {
-    let avail_balance = demo_okex_client().trading_account_balance().await?;
-    let minimum_balance = dec!(0);
-    assert!(avail_balance.amt_in_btc >= minimum_balance);
+    if let Some(client) = demo_okex_client() {
+        let avail_balance = client.trading_account_balance().await?;
+        let minimum_balance = dec!(0);
+        assert!(avail_balance.amt_in_btc >= minimum_balance);
+    }
 
     Ok(())
 }
@@ -106,11 +121,13 @@ async fn withdraw_to_onchain_address() -> anyhow::Result<()> {
     let amount = Decimal::from_str_exact(OKEX_MINIMUM_WITHDRAWAL_AMOUNT)?;
     let fee = Decimal::from_str_exact(OKEX_MINIMUM_WITHDRAWAL_FEE)?;
     if let Ok(onchain_address) = env::var("ONCHAIN_BTC_WITHDRAWAL_ADDRESS") {
-        let withdraw_id = demo_okex_client()
-            .withdraw_btc_onchain(amount, fee, onchain_address)
-            .await?;
+        if let Some(client) = demo_okex_client() {
+            let withdraw_id = client
+                .withdraw_btc_onchain(amount, fee, onchain_address)
+                .await?;
 
-        assert!(withdraw_id.value.len() == 8);
+            assert!(withdraw_id.value.len() == 8);
+        }
     }
     Ok(())
 }
@@ -118,12 +135,12 @@ async fn withdraw_to_onchain_address() -> anyhow::Result<()> {
 #[tokio::test]
 #[ignore = "transfer call is rate limited"]
 async fn transfer_trading_to_funding() -> anyhow::Result<()> {
-    let amount = dec!(0.00001);
-    let transfer_id = demo_okex_client()
-        .transfer_trading_to_funding(amount)
-        .await?;
+    if let Some(client) = demo_okex_client() {
+        let amount = dec!(0.00001);
+        let transfer_id = client.transfer_trading_to_funding(amount).await?;
 
-    assert!(transfer_id.value.len() == 9);
+        assert!(transfer_id.value.len() == 9);
+    }
 
     Ok(())
 }
@@ -131,12 +148,12 @@ async fn transfer_trading_to_funding() -> anyhow::Result<()> {
 #[tokio::test]
 #[ignore = "transfer call is rate limited"]
 async fn transfer_funding_to_trading() -> anyhow::Result<()> {
-    let amount = dec!(0.00001);
-    let transfer_id = demo_okex_client()
-        .transfer_funding_to_trading(amount)
-        .await?;
+    if let Some(client) = demo_okex_client() {
+        let amount = dec!(0.00001);
+        let transfer_id = client.transfer_funding_to_trading(amount).await?;
 
-    assert!(transfer_id.value.len() == 9);
+        assert!(transfer_id.value.len() == 9);
+    }
 
     Ok(())
 }
@@ -144,73 +161,82 @@ async fn transfer_funding_to_trading() -> anyhow::Result<()> {
 #[tokio::test]
 #[ignore = "transfer call is rate limited"]
 async fn transfer_state() -> anyhow::Result<()> {
-    let client = demo_okex_client();
-    let amount = dec!(0.00001);
-    let transfer_id = client.transfer_funding_to_trading(amount).await?;
+    if let Some(client) = demo_okex_client() {
+        let amount = dec!(0.00001);
+        let transfer_id = client.transfer_funding_to_trading(amount).await?;
 
-    let transfer_state = client.transfer_state(transfer_id).await?;
+        let transfer_state = client.transfer_state(transfer_id).await?;
 
-    assert_eq!(transfer_state.value, "success".to_string());
+        assert_eq!(transfer_state.value, "success".to_string());
+    }
 
     Ok(())
 }
 
 #[tokio::test]
 async fn place_order() -> anyhow::Result<()> {
-    let client = demo_okex_client();
-    let instrument = OkexInstrumentId::BtcUsdSwap;
-    let margin = OkexMarginMode::Cross;
-    let position_side = OkexPositionSide::LongShort(OkexPosition::Long);
-    let order_side = OkexOrderSide::Buy;
-    let order_type = OkexOrderType::Market;
+    if let Some(client) = demo_okex_client() {
+        let instrument = OkexInstrumentId::BtcUsdSwap;
+        let margin = OkexMarginMode::Cross;
+        let position_side = OkexPositionSide::Net;
+        let order_side = OkexOrderSide::Buy;
+        let order_type = OkexOrderType::Market;
 
-    let order_id = client
-        .place_order(instrument, margin, order_side, position_side, order_type, 1)
-        .await?;
+        let order_id = client
+            .place_order(instrument, margin, order_side, position_side, order_type, 1)
+            .await?;
 
-    assert!(order_id.value.len() == 18);
+        assert!(order_id.value.len() == 18);
+    }
 
     Ok(())
 }
 
 #[tokio::test]
 async fn get_positions() -> anyhow::Result<()> {
-    let client = demo_okex_client();
-    let position = client.get_position().await?;
+    if let Some(client) = demo_okex_client() {
+        let position = client.get_position().await?;
 
-    assert_eq!(position.value.len(), 18);
+        assert_eq!(position.value.len(), 18);
+    }
 
     Ok(())
 }
 
 #[tokio::test]
 async fn close_positions() -> anyhow::Result<()> {
-    let client = demo_okex_client();
-    let instrument = OkexInstrumentId::BtcUsdSwap;
-    let margin = OkexMarginMode::Cross;
-    let position_side = OkexPositionSide::LongShort(OkexPosition::Long);
-    let order_side = OkexOrderSide::Buy;
-    let order_type = OkexOrderType::Market;
+    if let Some(client) = demo_okex_client() {
+        let instrument = OkexInstrumentId::BtcUsdSwap;
+        let margin = OkexMarginMode::Cross;
+        let position_side = OkexPositionSide::Net;
+        let order_side = OkexOrderSide::Buy;
+        let order_type = OkexOrderType::Market;
 
-    // 1. Open position
-    client
-        .place_order(
-            instrument.clone(),
-            margin.clone(),
-            order_side,
-            position_side.clone(),
-            order_type,
-            1,
-        )
-        .await?;
+        // 1. Open position
+        client
+            .place_order(
+                instrument.clone(),
+                margin.clone(),
+                order_side,
+                position_side.clone(),
+                order_type,
+                1,
+            )
+            .await?;
 
-    // 2. Close position(s)
-    let position = client
-        .close_positions(instrument, position_side, margin, "BTC".to_string(), false)
-        .await?;
+        // 2. Close position(s)
+        let position = client
+            .close_positions(instrument, position_side, margin, "BTC".to_string(), false)
+            .await?;
 
-    assert_eq!(position.inst_id, "BTC-USD-SWAP".to_string());
-    assert_eq!(position.pos_side, "long".to_string());
+        assert_eq!(position.inst_id, "BTC-USD-SWAP".to_string());
+        assert_eq!(position.pos_side, "net".to_string());
+    }
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn set_position_mode() -> anyhow::Result<()> {
     Ok(())
 }

--- a/okex-price/src/price_feed/tick.rs
+++ b/okex-price/src/price_feed/tick.rs
@@ -3,9 +3,8 @@ use serde::Deserialize;
 
 use shared::time::*;
 
-#[derive(Clone, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-#[allow(clippy::derive_partial_eq_without_eq)]
 pub struct ChannelArgs {
     pub channel: String,
     pub inst_id: String,


### PR DESCRIPTION
## What this PR does?
- adds `position_mode` (`long_short_mode` vs `net_mode`) and `position_side` (`long`/`short`/`net`) to the `OkexClient` constructor. The latter is used as a type guard to ensure that client calls to the `place_order` and `close_positions` API pass in the acceptable side (`net`). 
- Clean-up (clippy): Derives Eq where PartialEq is derived
- Replace type casting of simulated configuration parameter with explicit type conversion

Note:
I started working on a method to get the current account configuration to ensure that the `position_mode` is the same as in the configuration, i.e. `net_mode`. This method could be used in the call to place an order but would mean an extra API call will be made to OKX, which is undesirable given the rate limits on their API.