### PR TITLE
fix: construct okex client if position mode is set to "net_mode"

### DIFF
--- a/okex-client/src/client/error.rs
+++ b/okex-client/src/client/error.rs
@@ -13,5 +13,5 @@ pub enum OkexClientError {
     #[error("OkexClientError: {0}")]
     DecimalConversion(#[from] rust_decimal::Error),
     #[error("OkexClientError: {code:?} - {msg:?}")]
-    PositionSide { msg: String, code: String },
+    PositionMode { msg: String, code: String },
 }

--- a/okex-client/src/client/mod.rs
+++ b/okex-client/src/client/mod.rs
@@ -58,12 +58,12 @@ impl OkexClient {
         let config_data =
             Self::extract_response_data::<OkexAccountConfigurationData>(response).await?;
 
-        // 2. Check postion_mode, i.e. order placement mode
+        // 2. Check position_mode, i.e. order placement mode
         if config_data.pos_mode == *"net_mode" {
             return Ok(client);
         }
         Err(OkexClientError::PositionMode {
-            msg: format!("Expected `net_mode`, got {}", config_data.pos_mode),
+            msg: format!("Expected `net_mode`, got `{}`", config_data.pos_mode),
             code: "0".to_string(),
         })
     }

--- a/okex-client/src/client/mod.rs
+++ b/okex-client/src/client/mod.rs
@@ -295,10 +295,10 @@ impl OkexClient {
         let mut body: HashMap<String, String> = HashMap::new();
         body.insert("ccy".to_string(), "BTC".to_string());
         body.insert("instId".to_string(), inst_id.to_string());
-        body.insert("tdMode".to_string(), OkexMarginMode::Cross.to_string());
+        body.insert("tdMode".to_string(), self.config.margin_mode.to_string());
         body.insert("side".to_string(), side.to_string());
-        body.insert("ordType".to_string(), OkexOrderType::Market.to_string());
-        body.insert("posSide".to_string(), OkexPositionSide::Net.to_string());
+        body.insert("ordType".to_string(), self.config.order_type.to_string());
+        body.insert("posSide".to_string(), self.config.position_side.to_string());
         body.insert("sz".to_string(), size.to_string());
         let request_body = serde_json::to_string(&body)?;
 
@@ -347,8 +347,8 @@ impl OkexClient {
     ) -> Result<ClosePositionData, OkexClientError> {
         let mut body: HashMap<String, String> = HashMap::new();
         body.insert("instId".to_string(), inst_id.to_string());
-        body.insert("mgnMode".to_string(), OkexMarginMode::Cross.to_string());
-        body.insert("posSide".to_string(), OkexPositionSide::Net.to_string());
+        body.insert("mgnMode".to_string(), self.config.margin_mode.to_string());
+        body.insert("posSide".to_string(), self.config.position_side.to_string());
         body.insert("ccy".to_string(), ccy);
         body.insert("autoCxl".to_string(), auto_cxl.to_string());
         let request_body = serde_json::to_string(&body)?;

--- a/okex-client/src/client/okex_response.rs
+++ b/okex-client/src/client/okex_response.rs
@@ -180,3 +180,17 @@ pub struct ClosePositionData {
     pub inst_id: String,
     pub pos_side: String,
 }
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct OkexAccountConfigurationData {
+    pub acct_lv: String,
+    pub auto_loan: bool,
+    pub ct_iso_mode: String,
+    pub greeks_type: String,
+    pub level: String,
+    pub level_tmp: String,
+    pub mgn_iso_mode: String,
+    pub pos_mode: String,
+    pub uid: String,
+}

--- a/okex-client/src/client/primitives.rs
+++ b/okex-client/src/client/primitives.rs
@@ -147,4 +147,6 @@ pub struct OkexClientConfig {
     pub simulated: bool,
     pub position_mode: OkexPositionMode,
     pub position_side: OkexPositionSide,
+    pub order_type: OkexOrderType,
+    pub margin_mode: OkexMarginMode,
 }

--- a/okex-client/tests/client.rs
+++ b/okex-client/tests/client.rs
@@ -61,7 +61,7 @@ async fn demo_okex_client() -> anyhow::Result<Option<OkexClient>> {
 
 #[tokio::test]
 async fn create_okex_client() -> anyhow::Result<()> {
-    let client = configured_okex_client().await;
+    let client = demo_okex_client().await;
 
     assert!(client.is_ok());
 
@@ -70,10 +70,8 @@ async fn create_okex_client() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn get_deposit_address_data() -> anyhow::Result<()> {
-    let address = configured_okex_client()
-        .await?
-        .get_funding_deposit_address()
-        .await?;
+    let client = configured_okex_client().await?;
+    let address = client.get_funding_deposit_address().await?;
     assert!(address.value.len() > 10);
 
     Ok(())
@@ -134,11 +132,9 @@ async fn deposit_status() -> anyhow::Result<()> {
         env::var("OKEX_DEPOSIT_AMOUNT"),
     ) {
         let amt = Decimal::from_str_exact(&deposit_amount)?;
+        let client = configured_okex_client().await?;
 
-        let deposit = configured_okex_client()
-            .await?
-            .fetch_deposit(deposit_addr, amt)
-            .await?;
+        let deposit = client.fetch_deposit(deposit_addr, amt).await?;
 
         assert_eq!(deposit.status, "2".to_string());
     }

--- a/okex-client/tests/client.rs
+++ b/okex-client/tests/client.rs
@@ -12,6 +12,8 @@ async fn configured_okex_client() -> anyhow::Result<OkexClient> {
     let simulated = false;
     let position_mode = OkexPositionMode::Net;
     let position_side = OkexPositionSide::Net;
+    let order_type = OkexOrderType::Market;
+    let margin_mode = OkexMarginMode::Cross;
 
     let client = OkexClient::create(OkexClientConfig {
         api_key,
@@ -20,6 +22,8 @@ async fn configured_okex_client() -> anyhow::Result<OkexClient> {
         simulated,
         position_mode,
         position_side,
+        order_type,
+        margin_mode,
     })
     .await?;
 
@@ -33,6 +37,8 @@ async fn demo_okex_client() -> anyhow::Result<Option<OkexClient>> {
     let simulated = true;
     let position_mode = OkexPositionMode::Net;
     let position_side = OkexPositionSide::Net;
+    let order_type = OkexOrderType::Market;
+    let margin_mode = OkexMarginMode::Cross;
 
     if let (Ok(api_key), Ok(passphrase), Ok(secret_key)) = (api_key, passphrase, secret_key) {
         let client = OkexClient::create(OkexClientConfig {
@@ -42,6 +48,8 @@ async fn demo_okex_client() -> anyhow::Result<Option<OkexClient>> {
             simulated,
             position_mode,
             position_side,
+            order_type,
+            margin_mode,
         })
         .await?;
 
@@ -80,6 +88,8 @@ async fn client_is_missing_header() -> anyhow::Result<()> {
         simulated: true,
         position_mode: OkexPositionMode::Net,
         position_side: OkexPositionSide::Net,
+        order_type: OkexOrderType::Market,
+        margin_mode: OkexMarginMode::Cross,
     })
     .await;
 

--- a/okex-client/tests/client.rs
+++ b/okex-client/tests/client.rs
@@ -5,7 +5,7 @@ use rust_decimal_macros::dec;
 
 use okex_client::*;
 
-fn configured_okex_client() -> OkexClient {
+async fn configured_okex_client() -> anyhow::Result<OkexClient> {
     let api_key = env::var("OKEX_API_KEY").expect("OKEX_API_KEY not set");
     let passphrase = env::var("OKEX_PASSPHRASE").expect("OKEX_PASS_PHRASE not set");
     let secret_key = env::var("OKEX_SECRET_KEY").expect("OKEX_SECRET_KEY not set");
@@ -13,7 +13,7 @@ fn configured_okex_client() -> OkexClient {
     let position_mode = OkexPositionMode::Net;
     let position_side = OkexPositionSide::Net;
 
-    OkexClient::new(OkexClientConfig {
+    let client = OkexClient::create(OkexClientConfig {
         api_key,
         passphrase,
         secret_key,
@@ -21,9 +21,12 @@ fn configured_okex_client() -> OkexClient {
         position_mode,
         position_side,
     })
+    .await?;
+
+    Ok(client)
 }
 
-fn demo_okex_client() -> Option<OkexClient> {
+async fn demo_okex_client() -> anyhow::Result<Option<OkexClient>> {
     let api_key = env::var("OKEX_DEMO_API_KEY");
     let passphrase = env::var("OKEX_DEMO_PASSPHRASE");
     let secret_key = env::var("OKEX_DEMO_SECRET_KEY");
@@ -32,21 +35,35 @@ fn demo_okex_client() -> Option<OkexClient> {
     let position_side = OkexPositionSide::Net;
 
     if let (Ok(api_key), Ok(passphrase), Ok(secret_key)) = (api_key, passphrase, secret_key) {
-        return Some(OkexClient::new(OkexClientConfig {
+        let client = OkexClient::create(OkexClientConfig {
             api_key,
             passphrase,
             secret_key,
             simulated,
             position_mode,
             position_side,
-        }));
+        })
+        .await?;
+
+        return Ok(Some(client));
     }
-    None
+
+    Ok(None)
+}
+
+#[tokio::test]
+async fn create_okex_client() -> anyhow::Result<()> {
+    let client = configured_okex_client().await;
+
+    assert!(client.is_ok());
+
+    Ok(())
 }
 
 #[tokio::test]
 async fn get_deposit_address_data() -> anyhow::Result<()> {
     let address = configured_okex_client()
+        .await?
         .get_funding_deposit_address()
         .await?;
     assert!(address.value.len() > 10);
@@ -56,18 +73,19 @@ async fn get_deposit_address_data() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn client_is_missing_header() -> anyhow::Result<()> {
-    let client = OkexClient::new(OkexClientConfig {
+    let client = OkexClient::create(OkexClientConfig {
         api_key: "".to_string(),
         passphrase: "".to_string(),
         secret_key: "".to_string(),
         simulated: true,
         position_mode: OkexPositionMode::Net,
         position_side: OkexPositionSide::Net,
-    });
+    })
+    .await;
 
-    let address = client.get_funding_deposit_address().await;
-    assert!(address.is_err());
-    if let Err(OkexClientError::UnexpectedResponse { msg, .. }) = address {
+    assert!(client.is_err());
+
+    if let Err(OkexClientError::UnexpectedResponse { msg, .. }) = client {
         assert!(msg.contains("header"));
     } else {
         assert!(false)
@@ -78,7 +96,7 @@ async fn client_is_missing_header() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn funding_account_balance() -> anyhow::Result<()> {
-    if let Some(client) = demo_okex_client() {
+    if let Some(client) = demo_okex_client().await? {
         let avail_balance = client.funding_account_balance().await?;
         let balance = avail_balance.amt_in_btc;
         let minimum_balance = dec!(0);
@@ -90,7 +108,7 @@ async fn funding_account_balance() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn trading_account_balance() -> anyhow::Result<()> {
-    if let Some(client) = demo_okex_client() {
+    if let Some(client) = demo_okex_client().await? {
         let avail_balance = client.trading_account_balance().await?;
         let minimum_balance = dec!(0);
         assert!(avail_balance.amt_in_btc >= minimum_balance);
@@ -108,6 +126,7 @@ async fn deposit_status() -> anyhow::Result<()> {
         let amt = Decimal::from_str_exact(&deposit_amount)?;
 
         let deposit = configured_okex_client()
+            .await?
             .fetch_deposit(deposit_addr, amt)
             .await?;
 
@@ -121,7 +140,7 @@ async fn withdraw_to_onchain_address() -> anyhow::Result<()> {
     let amount = Decimal::from_str_exact(OKEX_MINIMUM_WITHDRAWAL_AMOUNT)?;
     let fee = Decimal::from_str_exact(OKEX_MINIMUM_WITHDRAWAL_FEE)?;
     if let Ok(onchain_address) = env::var("ONCHAIN_BTC_WITHDRAWAL_ADDRESS") {
-        if let Some(client) = demo_okex_client() {
+        if let Some(client) = demo_okex_client().await? {
             let withdraw_id = client
                 .withdraw_btc_onchain(amount, fee, onchain_address)
                 .await?;
@@ -135,7 +154,7 @@ async fn withdraw_to_onchain_address() -> anyhow::Result<()> {
 #[tokio::test]
 #[ignore = "transfer call is rate limited"]
 async fn transfer_trading_to_funding() -> anyhow::Result<()> {
-    if let Some(client) = demo_okex_client() {
+    if let Some(client) = demo_okex_client().await? {
         let amount = dec!(0.00001);
         let transfer_id = client.transfer_trading_to_funding(amount).await?;
 
@@ -148,7 +167,7 @@ async fn transfer_trading_to_funding() -> anyhow::Result<()> {
 #[tokio::test]
 #[ignore = "transfer call is rate limited"]
 async fn transfer_funding_to_trading() -> anyhow::Result<()> {
-    if let Some(client) = demo_okex_client() {
+    if let Some(client) = demo_okex_client().await? {
         let amount = dec!(0.00001);
         let transfer_id = client.transfer_funding_to_trading(amount).await?;
 
@@ -161,7 +180,7 @@ async fn transfer_funding_to_trading() -> anyhow::Result<()> {
 #[tokio::test]
 #[ignore = "transfer call is rate limited"]
 async fn transfer_state() -> anyhow::Result<()> {
-    if let Some(client) = demo_okex_client() {
+    if let Some(client) = demo_okex_client().await? {
         let amount = dec!(0.00001);
         let transfer_id = client.transfer_funding_to_trading(amount).await?;
 
@@ -175,16 +194,11 @@ async fn transfer_state() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn place_order() -> anyhow::Result<()> {
-    if let Some(client) = demo_okex_client() {
+    if let Some(client) = demo_okex_client().await? {
         let instrument = OkexInstrumentId::BtcUsdSwap;
-        let margin = OkexMarginMode::Cross;
-        let position_side = OkexPositionSide::Net;
         let order_side = OkexOrderSide::Buy;
-        let order_type = OkexOrderType::Market;
 
-        let order_id = client
-            .place_order(instrument, margin, order_side, position_side, order_type, 1)
-            .await?;
+        let order_id = client.place_order(instrument, order_side, 1).await?;
 
         assert!(order_id.value.len() == 18);
     }
@@ -194,7 +208,7 @@ async fn place_order() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn get_positions() -> anyhow::Result<()> {
-    if let Some(client) = demo_okex_client() {
+    if let Some(client) = demo_okex_client().await? {
         let position = client.get_position().await?;
 
         assert_eq!(position.value.len(), 18);
@@ -205,38 +219,22 @@ async fn get_positions() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn close_positions() -> anyhow::Result<()> {
-    if let Some(client) = demo_okex_client() {
+    if let Some(client) = demo_okex_client().await? {
         let instrument = OkexInstrumentId::BtcUsdSwap;
-        let margin = OkexMarginMode::Cross;
-        let position_side = OkexPositionSide::Net;
         let order_side = OkexOrderSide::Buy;
-        let order_type = OkexOrderType::Market;
+        let currency = "BTC".to_string();
 
         // 1. Open position
         client
-            .place_order(
-                instrument.clone(),
-                margin.clone(),
-                order_side,
-                position_side.clone(),
-                order_type,
-                1,
-            )
+            .place_order(instrument.clone(), order_side, 1)
             .await?;
 
         // 2. Close position(s)
-        let position = client
-            .close_positions(instrument, position_side, margin, "BTC".to_string(), false)
-            .await?;
+        let position = client.close_positions(instrument, currency, false).await?;
 
         assert_eq!(position.inst_id, "BTC-USD-SWAP".to_string());
         assert_eq!(position.pos_side, "net".to_string());
     }
 
-    Ok(())
-}
-
-#[tokio::test]
-async fn set_position_mode() -> anyhow::Result<()> {
     Ok(())
 }


### PR DESCRIPTION
## What this PR does
- constructs  `OkexClient` only if the position mode (i.e. order placement) is set to `"net_mode"`
- adds position_side of `"net"`, order_type of `"market"`, and margin_mode of `"cross"` to config

## Context
- Related PR: #71 
- Addresses this [comment](https://github.com/GaloyMoney/stablesats-rs/pull/71#issuecomment-1221382482)