### PR TITLE
feat: remove margin_mode, position_side, order_type from config

### DIFF
--- a/okex-client/src/client/error.rs
+++ b/okex-client/src/client/error.rs
@@ -12,6 +12,6 @@ pub enum OkexClientError {
     UnexpectedResponse { msg: String, code: String },
     #[error("OkexClientError: {0}")]
     DecimalConversion(#[from] rust_decimal::Error),
-    #[error("OkexClientError: {code:?} - {msg:?}")]
-    PositionMode { msg: String, code: String },
+    #[error("OkexClientError: {0}")]
+    MisconfiguredAccount(String),
 }

--- a/okex-client/src/client/mod.rs
+++ b/okex-client/src/client/mod.rs
@@ -94,7 +94,7 @@ impl OkexClient {
         amt: Decimal,
     ) -> Result<TransferId, OkexClientError> {
         let mut body: HashMap<String, String> = HashMap::new();
-        body.insert("ccy".to_string(), "BTC".to_string());
+        body.insert("ccy".to_string(), TradeCurrency::BTC.to_string());
         body.insert("amt".to_string(), amt.to_string());
         body.insert("from".to_string(), "6".to_string());
         body.insert("to".to_string(), "18".to_string());
@@ -123,7 +123,7 @@ impl OkexClient {
         amt: Decimal,
     ) -> Result<TransferId, OkexClientError> {
         let mut body: HashMap<String, String> = HashMap::new();
-        body.insert("ccy".to_string(), "BTC".to_string());
+        body.insert("ccy".to_string(), TradeCurrency::BTC.to_string());
         body.insert("amt".to_string(), amt.to_string());
         body.insert("from".to_string(), "18".to_string());
         body.insert("to".to_string(), "6".to_string());
@@ -220,7 +220,7 @@ impl OkexClient {
         btc_address: String,
     ) -> Result<WithdrawId, OkexClientError> {
         let mut body: HashMap<String, String> = HashMap::new();
-        body.insert("ccy".to_string(), "BTC".to_string());
+        body.insert("ccy".to_string(), TradeCurrency::BTC.to_string());
         body.insert("amt".to_string(), amt.to_string());
         body.insert("dest".to_string(), "4".to_string());
         body.insert("fee".to_string(), fee.to_string());
@@ -289,7 +289,7 @@ impl OkexClient {
         size: u64,
     ) -> Result<OrderId, OkexClientError> {
         let mut body: HashMap<String, String> = HashMap::new();
-        body.insert("ccy".to_string(), "BTC".to_string());
+        body.insert("ccy".to_string(), TradeCurrency::BTC.to_string());
         body.insert("instId".to_string(), inst_id.to_string());
         body.insert("tdMode".to_string(), OkexMarginMode::Cross.to_string());
         body.insert("side".to_string(), side.to_string());
@@ -338,14 +338,13 @@ impl OkexClient {
     pub async fn close_positions(
         &self,
         inst_id: OkexInstrumentId,
-        ccy: String,
         auto_cxl: bool,
     ) -> Result<ClosePositionData, OkexClientError> {
         let mut body: HashMap<String, String> = HashMap::new();
         body.insert("instId".to_string(), inst_id.to_string());
         body.insert("mgnMode".to_string(), OkexMarginMode::Cross.to_string());
         body.insert("posSide".to_string(), OkexPositionSide::Net.to_string());
-        body.insert("ccy".to_string(), ccy);
+        body.insert("ccy".to_string(), TradeCurrency::BTC.to_string());
         body.insert("autoCxl".to_string(), auto_cxl.to_string());
         let request_body = serde_json::to_string(&body)?;
 

--- a/okex-client/src/client/mod.rs
+++ b/okex-client/src/client/mod.rs
@@ -291,10 +291,10 @@ impl OkexClient {
         let mut body: HashMap<String, String> = HashMap::new();
         body.insert("ccy".to_string(), "BTC".to_string());
         body.insert("instId".to_string(), inst_id.to_string());
-        body.insert("tdMode".to_string(), self.config.margin_mode.to_string());
+        body.insert("tdMode".to_string(), OkexMarginMode::Cross.to_string());
         body.insert("side".to_string(), side.to_string());
-        body.insert("ordType".to_string(), self.config.order_type.to_string());
-        body.insert("posSide".to_string(), self.config.position_side.to_string());
+        body.insert("ordType".to_string(), OkexOrderType::Market.to_string());
+        body.insert("posSide".to_string(), OkexPositionSide::Net.to_string());
         body.insert("sz".to_string(), size.to_string());
         let request_body = serde_json::to_string(&body)?;
 
@@ -343,8 +343,8 @@ impl OkexClient {
     ) -> Result<ClosePositionData, OkexClientError> {
         let mut body: HashMap<String, String> = HashMap::new();
         body.insert("instId".to_string(), inst_id.to_string());
-        body.insert("mgnMode".to_string(), self.config.margin_mode.to_string());
-        body.insert("posSide".to_string(), self.config.position_side.to_string());
+        body.insert("mgnMode".to_string(), OkexMarginMode::Cross.to_string());
+        body.insert("posSide".to_string(), OkexPositionSide::Net.to_string());
         body.insert("ccy".to_string(), ccy);
         body.insert("autoCxl".to_string(), auto_cxl.to_string());
         let request_body = serde_json::to_string(&body)?;

--- a/okex-client/src/client/primitives.rs
+++ b/okex-client/src/client/primitives.rs
@@ -147,3 +147,18 @@ pub struct OkexClientConfig {
     pub simulated: bool,
     pub position_mode: OkexPositionMode,
 }
+
+#[derive(Debug, Clone)]
+pub enum TradeCurrency {
+    BTC,
+    USD,
+}
+
+impl Display for TradeCurrency {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            TradeCurrency::BTC => write!(f, "BTC"),
+            TradeCurrency::USD => write!(f, "USD"),
+        }
+    }
+}

--- a/okex-client/src/client/primitives.rs
+++ b/okex-client/src/client/primitives.rs
@@ -146,7 +146,4 @@ pub struct OkexClientConfig {
     pub secret_key: String,
     pub simulated: bool,
     pub position_mode: OkexPositionMode,
-    pub position_side: OkexPositionSide,
-    pub order_type: OkexOrderType,
-    pub margin_mode: OkexMarginMode,
 }

--- a/okex-client/tests/client.rs
+++ b/okex-client/tests/client.rs
@@ -213,7 +213,6 @@ async fn close_positions() -> anyhow::Result<()> {
     if let Some(client) = demo_okex_client().await? {
         let instrument = OkexInstrumentId::BtcUsdSwap;
         let order_side = OkexOrderSide::Buy;
-        let currency = "BTC".to_string();
 
         // 1. Open position
         client
@@ -221,7 +220,7 @@ async fn close_positions() -> anyhow::Result<()> {
             .await?;
 
         // 2. Close position(s)
-        let position = client.close_positions(instrument, currency, false).await?;
+        let position = client.close_positions(instrument, false).await?;
 
         assert_eq!(position.inst_id, "BTC-USD-SWAP".to_string());
         assert_eq!(position.pos_side, "net".to_string());

--- a/okex-client/tests/client.rs
+++ b/okex-client/tests/client.rs
@@ -11,9 +11,6 @@ async fn configured_okex_client() -> anyhow::Result<OkexClient> {
     let secret_key = env::var("OKEX_SECRET_KEY").expect("OKEX_SECRET_KEY not set");
     let simulated = false;
     let position_mode = OkexPositionMode::Net;
-    let position_side = OkexPositionSide::Net;
-    let order_type = OkexOrderType::Market;
-    let margin_mode = OkexMarginMode::Cross;
 
     let client = OkexClient::new(OkexClientConfig {
         api_key,
@@ -21,9 +18,6 @@ async fn configured_okex_client() -> anyhow::Result<OkexClient> {
         secret_key,
         simulated,
         position_mode,
-        position_side,
-        order_type,
-        margin_mode,
     })
     .await?;
 
@@ -36,9 +30,6 @@ async fn demo_okex_client() -> anyhow::Result<Option<OkexClient>> {
     let secret_key = env::var("OKEX_DEMO_SECRET_KEY");
     let simulated = true;
     let position_mode = OkexPositionMode::Net;
-    let position_side = OkexPositionSide::Net;
-    let order_type = OkexOrderType::Market;
-    let margin_mode = OkexMarginMode::Cross;
 
     if let (Ok(api_key), Ok(passphrase), Ok(secret_key)) = (api_key, passphrase, secret_key) {
         let client = OkexClient::new(OkexClientConfig {
@@ -47,9 +38,6 @@ async fn demo_okex_client() -> anyhow::Result<Option<OkexClient>> {
             secret_key,
             simulated,
             position_mode,
-            position_side,
-            order_type,
-            margin_mode,
         })
         .await?;
 
@@ -85,9 +73,6 @@ async fn client_is_missing_header() -> anyhow::Result<()> {
         secret_key: "".to_string(),
         simulated: true,
         position_mode: OkexPositionMode::Net,
-        position_side: OkexPositionSide::Net,
-        order_type: OkexOrderType::Market,
-        margin_mode: OkexMarginMode::Cross,
     })
     .await;
 

--- a/okex-client/tests/client.rs
+++ b/okex-client/tests/client.rs
@@ -15,7 +15,7 @@ async fn configured_okex_client() -> anyhow::Result<OkexClient> {
     let order_type = OkexOrderType::Market;
     let margin_mode = OkexMarginMode::Cross;
 
-    let client = OkexClient::create(OkexClientConfig {
+    let client = OkexClient::new(OkexClientConfig {
         api_key,
         passphrase,
         secret_key,
@@ -41,7 +41,7 @@ async fn demo_okex_client() -> anyhow::Result<Option<OkexClient>> {
     let margin_mode = OkexMarginMode::Cross;
 
     if let (Ok(api_key), Ok(passphrase), Ok(secret_key)) = (api_key, passphrase, secret_key) {
-        let client = OkexClient::create(OkexClientConfig {
+        let client = OkexClient::new(OkexClientConfig {
             api_key,
             passphrase,
             secret_key,
@@ -79,7 +79,7 @@ async fn get_deposit_address_data() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn client_is_missing_header() -> anyhow::Result<()> {
-    let client = OkexClient::create(OkexClientConfig {
+    let client = OkexClient::new(OkexClientConfig {
         api_key: "".to_string(),
         passphrase: "".to_string(),
         secret_key: "".to_string(),


### PR DESCRIPTION
## What does this PR do?
- Remove `margin_mode`, `position_side`, and `order_type` from OkexClient config, alongside code cleanup
- Related: #78 