### PR TITLE
refactor: extract balance update into single query

### DIFF
--- a/user-trades/sqlx-data.json
+++ b/user-trades/sqlx-data.json
@@ -44,130 +44,6 @@
     },
     "query": "INSERT INTO user_trades (uuid, buy_unit, buy_amount, sell_unit, sell_amount) VALUES ($1, $2, $3, $4, $5) RETURNING idx"
   },
-  "27702793a9046cc0abd9157698cb260292eabe86d667d703af5cf52439a21ca9": {
-    "describe": {
-      "columns": [
-        {
-          "name": "unit: _",
-          "ordinal": 0,
-          "type_info": {
-            "Custom": {
-              "kind": {
-                "Enum": [
-                  "sats",
-                  "synth_cents"
-                ]
-              },
-              "name": "user_trade_unit"
-            }
-          }
-        },
-        {
-          "name": "current_balance",
-          "ordinal": 1,
-          "type_info": "Numeric"
-        },
-        {
-          "name": "last_trade_idx",
-          "ordinal": 2,
-          "type_info": "Int4"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        true
-      ],
-      "parameters": {
-        "Left": []
-      }
-    },
-    "query": "SELECT unit as \"unit: _\", current_balance, last_trade_idx FROM user_trade_balances FOR UPDATE"
-  },
-  "2fe2d3b6d0a02794059cb16d14bf411a5a836d1c0179e869fce61066d497859d": {
-    "describe": {
-      "columns": [
-        {
-          "name": "max",
-          "ordinal": 0,
-          "type_info": "Int4"
-        },
-        {
-          "name": "unit: _",
-          "ordinal": 1,
-          "type_info": {
-            "Custom": {
-              "kind": {
-                "Enum": [
-                  "sats",
-                  "synth_cents"
-                ]
-              },
-              "name": "user_trade_unit"
-            }
-          }
-        },
-        {
-          "name": "sum",
-          "ordinal": 2,
-          "type_info": "Numeric"
-        }
-      ],
-      "nullable": [
-        null,
-        false,
-        null
-      ],
-      "parameters": {
-        "Left": [
-          "Int4"
-        ]
-      }
-    },
-    "query": "SELECT MAX(idx), sell_unit as \"unit: _\", SUM(sell_amount) FROM user_trades WHERE idx > $1 GROUP BY sell_unit"
-  },
-  "31b5f2ea7ffd150454c028ddf66e47cfe64141d127b770de709ae76099a529b1": {
-    "describe": {
-      "columns": [
-        {
-          "name": "max",
-          "ordinal": 0,
-          "type_info": "Int4"
-        },
-        {
-          "name": "unit: _",
-          "ordinal": 1,
-          "type_info": {
-            "Custom": {
-              "kind": {
-                "Enum": [
-                  "sats",
-                  "synth_cents"
-                ]
-              },
-              "name": "user_trade_unit"
-            }
-          }
-        },
-        {
-          "name": "sum",
-          "ordinal": 2,
-          "type_info": "Numeric"
-        }
-      ],
-      "nullable": [
-        null,
-        false,
-        null
-      ],
-      "parameters": {
-        "Left": [
-          "Int4"
-        ]
-      }
-    },
-    "query": "SELECT MAX(idx), buy_unit as \"unit: _\", SUM(buy_amount) FROM user_trades WHERE idx > $1 GROUP BY buy_unit"
-  },
   "4c55cf33910332998f88deed9a08f8a1bfe8d371e45a5894e18e5c1893789ec4": {
     "describe": {
       "columns": [],
@@ -231,5 +107,65 @@
       }
     },
     "query": "SELECT unit as \"unit: _\", current_balance, last_trade_idx FROM user_trade_balances"
+  },
+  "c198a77cbfdbd8c53702b6e24850a657cca2fd92170f5d650c6e585e412e5b3a": {
+    "describe": {
+      "columns": [
+        {
+          "name": "last_trade_idx",
+          "ordinal": 0,
+          "type_info": "Int4"
+        }
+      ],
+      "nullable": [
+        true
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "SELECT last_trade_idx FROM user_trade_balances FOR UPDATE"
+  },
+  "d53779f1c1f6b66bfdc428b04a70201f344ab402278a2e017c931eb55e8a7d7f": {
+    "describe": {
+      "columns": [
+        {
+          "name": "unit: _",
+          "ordinal": 0,
+          "type_info": {
+            "Custom": {
+              "kind": {
+                "Enum": [
+                  "sats",
+                  "synth_cents"
+                ]
+              },
+              "name": "user_trade_unit"
+            }
+          }
+        },
+        {
+          "name": "new_balance",
+          "ordinal": 1,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "new_latest_idx",
+          "ordinal": 2,
+          "type_info": "Int4"
+        }
+      ],
+      "nullable": [
+        false,
+        null,
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "Int4"
+        ]
+      }
+    },
+    "query": " WITH buy_amounts AS (\n   SELECT MAX(idx) as max_buy, buy_unit, SUM(buy_amount) AS to_sub FROM user_trades WHERE idx > $1 GROUP BY buy_unit\n ),\n sell_amounts AS (\n   SELECT MAX(idx) as max_sell, sell_unit, SUM(sell_amount) AS to_add FROM user_trades WHERE idx > $1 GROUP BY sell_unit\n )\nSELECT\n  unit AS \"unit: _\",\n  current_balance + COALESCE(to_add, 0) - COALESCE(to_sub, 0) AS new_balance,\n  MAX(GREATEST(max_buy, max_sell)) OVER () AS new_latest_idx\nFROM user_trade_balances\nLEFT JOIN buy_amounts ON unit=buy_unit\nLEFT JOIN sell_amounts ON unit=sell_unit;\n"
   }
 }

--- a/user-trades/src/user_trade_balances/sql/new-balance.sql
+++ b/user-trades/src/user_trade_balances/sql/new-balance.sql
@@ -1,0 +1,13 @@
+ WITH buy_amounts AS (
+   SELECT MAX(idx) as max_buy, buy_unit, SUM(buy_amount) AS to_sub FROM user_trades WHERE idx > $1 GROUP BY buy_unit
+ ),
+ sell_amounts AS (
+   SELECT MAX(idx) as max_sell, sell_unit, SUM(sell_amount) AS to_add FROM user_trades WHERE idx > $1 GROUP BY sell_unit
+ )
+SELECT
+  unit AS "unit: _",
+  current_balance + COALESCE(to_add, 0) - COALESCE(to_sub, 0) AS new_balance,
+  MAX(GREATEST(max_buy, max_sell)) OVER () AS new_latest_idx
+FROM user_trade_balances
+LEFT JOIN buy_amounts ON unit=buy_unit
+LEFT JOIN sell_amounts ON unit=sell_unit;

--- a/user-trades/tests/user_trade_balances.rs
+++ b/user-trades/tests/user_trade_balances.rs
@@ -19,12 +19,16 @@ async fn user_trade_balances() -> anyhow::Result<()> {
     let original_balances = balances.fetch_all().await?;
 
     let trades = UserTrades::new(POOL.clone());
+
+    let sat_amount = dec!(1000);
+    let cent_amount = dec!(10);
+
     let trade = trades
         .persist_new(NewUserTrade::new(
             UserTradeUnit::SynthCents,
-            dec!(10),
+            cent_amount,
             UserTradeUnit::Sats,
-            dec!(1000),
+            sat_amount,
         ))
         .await?;
 
@@ -40,7 +44,7 @@ async fn user_trade_balances() -> anyhow::Result<()> {
 
     assert_eq!(new_sat_summary.last_trade_idx, Some(trade.idx));
     assert_eq!(
-        old_sat_summary.current_balance + dec!(1000),
+        old_sat_summary.current_balance + sat_amount,
         new_sat_summary.current_balance
     );
 
@@ -53,7 +57,7 @@ async fn user_trade_balances() -> anyhow::Result<()> {
 
     assert_eq!(new_cent_summary.last_trade_idx, Some(trade.idx));
     assert_eq!(
-        old_cent_summary.current_balance - dec!(10),
+        old_cent_summary.current_balance - cent_amount,
         new_cent_summary.current_balance
     );
 


### PR DESCRIPTION
Simplified some application code into a single query:
```
 WITH buy_amounts AS (
    SELECT MAX(idx) as max_buy, buy_unit, SUM(buy_amount) AS to_sub FROM user_trades WHERE idx > $1 GROUP BY buy_unit
  ),
  sell_amounts AS (
    SELECT MAX(idx) as max_sell, sell_unit, SUM(sell_amount) AS to_add FROM user_trades WHERE idx > $1 GROUP BY sell_unit
  )
 SELECT
   unit AS "unit: _",
   current_balance + COALESCE(to_add, 0) - COALESCE(to_sub, 0) AS new_balance,
   MAX(GREATEST(max_buy, max_sell)) OVER () AS new_latest_idx
 FROM user_trade_balances
 LEFT JOIN buy_amounts ON unit=buy_unit
 LEFT JOIN sell_amounts ON unit=sell_unit;
 ```
 
 but is this readable for you @enigbe @sebastienverreault ?
 
 It is about 50% less code and more performant to do it like this but you have to know your SQL.
 
 WDYT is using SQL directly a style we want to go with? I would be in favour but want your input.