### PR TITLE
chore: disable hedging and user-trades crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,7 +882,6 @@ dependencies = [
 name = "hedging"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "chrono",
  "futures",
  "okex-client",
@@ -891,7 +890,6 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "serial_test",
  "sqlx",
  "sqlxmq",
  "stablesats-shared",
@@ -2919,12 +2917,10 @@ dependencies = [
  "chrono",
  "futures",
  "galoy-client",
- "lazy_static",
  "rust_decimal",
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "serial_test",
  "sqlx",
  "sqlxmq",
  "stablesats-shared",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,12 @@ members = [
   "shared",
   "price-server",
   "cli",
-  "hedging",
-  "user-trades",
   "okex-price",
   "okex-client",
   "galoy-client",
+]
+
+exclude = [
+  "hedging",
+  "user-trades",
 ]


### PR DESCRIPTION
## What this PR does?
- excludes `hedging` and `user-trades` crate from the workspace