### PR TITLE
fix(cli): add missing configuration for `run` command

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -41,15 +41,27 @@ enum Command {
         /// Phone code for the galoy client
         #[clap(env = "GALOY_PHONE_CODE", default_value = "")]
         galoy_phone_code: String,
+        /// Phone number for the galoy client
+        #[clap(env = "GALOY_PHONE_NUMBER", default_value = "")]
+        galoy_phone_number: String,
+        /// API for the galoy client
+        #[clap(env = "GALOY_API", default_value = "")]
+        galoy_api: String,
         /// Connection string for the hedging database
         #[clap(env = "HEDGING_PG_CON", default_value = "")]
         hedging_pg_con: String,
+        /// Okex access key
+        #[clap(env = "OKEX_API_KEY", default_value = "")]
+        okex_api_key: String,
         /// Okex secret key
         #[clap(env = "OKEX_SECRET_KEY", default_value = "")]
         okex_secret_key: String,
         /// Okex passphrase
         #[clap(env = "OKEX_PASSPHRASE", default_value = "")]
         okex_passphrase: String,
+        /// Okex simulation flag, either "true" or "false"
+        #[clap(env = "OKEX_SIMULATED", default_value = "true")]
+        okex_simulated: String,
     },
     /// Gets a quote from the price server
     Price {
@@ -74,7 +86,11 @@ pub async fn run() -> anyhow::Result<()> {
             crash_report_config,
             user_trades_pg_con,
             galoy_phone_code,
+            galoy_phone_number,
+            galoy_api,
+            okex_api_key,
             okex_passphrase,
+            okex_simulated,
             okex_secret_key,
             hedging_pg_con,
         } => {
@@ -84,8 +100,12 @@ pub async fn run() -> anyhow::Result<()> {
                     redis_password,
                     user_trades_pg_con,
                     galoy_phone_code,
+                    galoy_phone_number,
+                    galoy_api,
                     okex_passphrase,
+                    okex_api_key,
                     okex_secret_key,
+                    okex_simulated,
                     hedging_pg_con,
                 },
             )?;

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -36,9 +36,13 @@ pub struct EnvOverride {
     pub redis_password: Option<String>,
     pub user_trades_pg_con: String,
     pub hedging_pg_con: String,
+    pub okex_api_key: String,
     pub okex_secret_key: String,
+    pub okex_simulated: String,
     pub okex_passphrase: String,
     pub galoy_phone_code: String,
+    pub galoy_phone_number: String,
+    pub galoy_api: String,
 }
 
 impl Config {
@@ -48,6 +52,10 @@ impl Config {
             redis_password,
             user_trades_pg_con,
             galoy_phone_code,
+            galoy_phone_number,
+            galoy_api,
+            okex_api_key,
+            okex_simulated,
             okex_passphrase,
             okex_secret_key,
             hedging_pg_con,
@@ -62,8 +70,16 @@ impl Config {
 
         config.user_trades.config.pg_con = user_trades_pg_con;
         config.galoy.auth_code = galoy_phone_code;
+        config.galoy.phone_number = galoy_phone_number;
+        config.galoy.api = galoy_api;
         config.hedging.config.pg_con = hedging_pg_con;
+        config.okex.api_key = okex_api_key;
         config.okex.secret_key = okex_secret_key;
+        config.okex.simulated = match okex_simulated.as_str() {
+            "true" => true,
+            "false" => false,
+            _ => false,
+        };
         config.okex.passphrase = okex_passphrase;
 
         Ok(config)


### PR DESCRIPTION
## What this PR does?
- A handful of configuration parameters are required by the `okex_client` and `galoy_client` to connect successfully to their respective servers.
- For the `okex_client`, the API key and simulation flag have been added to `Command::Run {...}`. The former is required to generate a valid access key, and the latter to determine the environment (`live` or `demo`) of the trading API.
- For the `galoy_client`, the phone code and API base url were added `Command::Run {...}`. Without the phone code, a valid JWT is not generated by the galoy graphql API.
