### PR TITLE
feat: health-check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,8 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde",
+ "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tower",
@@ -2456,6 +2458,7 @@ name = "stablesats"
 version = "0.3.4-dev"
 dependencies = [
  "anyhow",
+ "axum",
  "clap",
  "futures",
  "galoy-client",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,3 +30,4 @@ tracing = "0.1.36"
 opentelemetry-jaeger = { version = "0.17.0", features = ["rt-tokio"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 tracing-opentelemetry = "0.18.0"
+axum = "0.5.16"

--- a/cli/src/health.rs
+++ b/cli/src/health.rs
@@ -1,0 +1,44 @@
+use anyhow::Context;
+use axum::{http::StatusCode, response::IntoResponse, routing::get, Router};
+use futures::SinkExt;
+use std::{net::SocketAddr, sync::Arc};
+
+use shared::health::HealthChecker;
+
+async fn health(checkers: Arc<Vec<HealthChecker>>) -> impl IntoResponse {
+    for checker in checkers.iter() {
+        let (snd, recv) = futures::channel::oneshot::channel();
+        if let Err(e) = checker.clone().send(snd).await {
+            eprintln!("Couldn't send health check: {}", e);
+            return StatusCode::SERVICE_UNAVAILABLE;
+        }
+        match tokio::time::timeout(std::time::Duration::from_millis(100), recv).await {
+            Err(_) => {
+                eprintln!("Health check timed out");
+                return StatusCode::SERVICE_UNAVAILABLE;
+            }
+            Ok(Err(e)) => {
+                eprintln!("Health check failed: {}", e);
+                return StatusCode::SERVICE_UNAVAILABLE;
+            }
+            Ok(Ok(_)) => (),
+        }
+    }
+    StatusCode::OK
+}
+
+pub async fn run(checkers: Vec<HealthChecker>) -> anyhow::Result<()> {
+    let app = Router::new().route(
+        "/healthz",
+        get({
+            let checkers = Arc::new(checkers);
+            move || health(Arc::clone(&checkers))
+        }),
+    );
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], 8080));
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await
+        .context("Bind health server")
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod app;
 pub mod config;
+mod health;
 mod tracing;
 
 mod price_client;

--- a/hedging/src/app/mod.rs
+++ b/hedging/src/app/mod.rs
@@ -112,6 +112,7 @@ impl HedgingApp {
                     message_type = %msg.payload_type,
                     correlation_id = %correlation_id,
                     error = tracing::field::Empty,
+                    error.level = tracing::field::Empty,
                     error.message = tracing::field::Empty,
                 );
                 shared::tracing::inject_tracing_data(&span, &msg.meta.tracing_data);
@@ -144,7 +145,7 @@ impl HedgingApp {
             }
             Ok(None) => Ok(()),
             Err(e) => {
-                shared::tracing::insert_error_fields(&e);
+                shared::tracing::insert_error_fields(tracing::Level::ERROR, &e);
                 Err(e)
             }
         }

--- a/hedging/src/job/mod.rs
+++ b/hedging/src/job/mod.rs
@@ -112,34 +112,43 @@ async fn poll_okex(
         attempt = tracing::field::Empty,
         last_attempt = false,
         error = tracing::field::Empty,
+        error.level = tracing::field::Empty,
         error.message = tracing::field::Empty,
     );
-    shared::tracing::record_error(tracing::Level::WARN, || async move {
-        let mut job_completed = false;
-        if let Ok(tracker) = update_tracker(&mut current_job).await {
-            if tracker.attempts > 5 {
-                Span::current().record("last_attempt", &true);
-                current_job.complete().await?;
-                job_completed = true;
+    let tracker = current_tracker(&mut current_job);
+    shared::tracing::record_error(
+        if tracker.attempts >= 4 {
+            tracing::Level::ERROR
+        } else {
+            tracing::Level::WARN
+        },
+        || async move {
+            let mut job_completed = false;
+            if let Ok(tracker) = update_tracker(&mut current_job).await {
+                if tracker.attempts > 5 {
+                    Span::current().record("last_attempt", &true);
+                    current_job.complete().await?;
+                    job_completed = true;
+                }
             }
-        }
-        let PositionSize {
-            usd_cents,
-            instrument_id,
-        } = okex.get_position_in_signed_usd_cents().await?;
-        publisher
-            .publish(OkexBtcUsdSwapPositionPayload {
-                exchange: ExchangeIdRaw::from(OKEX_EXCHANGE_ID),
-                instrument_id: InstrumentIdRaw::from(instrument_id.to_string()),
-                signed_usd_exposure: SyntheticCentExposure::from(usd_cents),
-            })
-            .await?;
-        if !job_completed {
-            current_job.complete().await?;
-        }
-        spawn_poll_okex(current_job.pool(), delay).await?;
-        Ok(())
-    })
+            let PositionSize {
+                usd_cents,
+                instrument_id,
+            } = okex.get_position_in_signed_usd_cents().await?;
+            publisher
+                .publish(OkexBtcUsdSwapPositionPayload {
+                    exchange: ExchangeIdRaw::from(OKEX_EXCHANGE_ID),
+                    instrument_id: InstrumentIdRaw::from(instrument_id.to_string()),
+                    signed_usd_exposure: SyntheticCentExposure::from(usd_cents),
+                })
+                .await?;
+            if !job_completed {
+                current_job.complete().await?;
+            }
+            spawn_poll_okex(current_job.pool(), delay).await?;
+            Ok(())
+        },
+    )
     .instrument(span)
     .await
 }
@@ -161,34 +170,46 @@ async fn adjust_hedge(
         job_id = %current_job.id(),
         job_name = %current_job.name(),
         error = tracing::field::Empty,
+        error.level = tracing::field::Empty,
         error.message = tracing::field::Empty,
     );
     shared::tracing::inject_tracing_data(&span, &tracing_data);
-    shared::tracing::record_error(tracing::Level::WARN, || async move {
-        adjust_hedge::execute(
-            current_job,
-            correlation_id,
-            synth_usd_liability,
-            okex,
-            hedging_adjustments,
-        )
-        .await
-    })
+    let tracker = current_tracker(&current_job);
+    shared::tracing::record_error(
+        if tracker.attempts >= 10 {
+            tracing::Level::ERROR
+        } else {
+            tracing::Level::WARN
+        },
+        || async move {
+            adjust_hedge::execute(
+                current_job,
+                correlation_id,
+                synth_usd_liability,
+                okex,
+                hedging_adjustments,
+            )
+            .await
+        },
+    )
     .instrument(span)
     .await?;
     Ok(())
 }
 
+fn current_tracker(current_job: &CurrentJob) -> AttemptTracker {
+    if let Ok(Some(AttemptTracker { attempts })) = current_job.json::<AttemptTracker>() {
+        AttemptTracker {
+            attempts: attempts + 1,
+        }
+    } else {
+        AttemptTracker { attempts: 1 }
+    }
+}
+
 async fn update_tracker(current_job: &mut CurrentJob) -> Result<AttemptTracker, HedgingError> {
     let mut checkpoint = sqlxmq::Checkpoint::new();
-    let tracker =
-        if let Ok(Some(AttemptTracker { attempts })) = current_job.json::<AttemptTracker>() {
-            AttemptTracker {
-                attempts: attempts + 1,
-            }
-        } else {
-            AttemptTracker { attempts: 1 }
-        };
+    let tracker = current_tracker(current_job);
     Span::current().record("attempt", &tracing::field::display(tracker.attempts));
     checkpoint
         .set_json(&tracker)

--- a/hedging/src/job/mod.rs
+++ b/hedging/src/job/mod.rs
@@ -115,7 +115,7 @@ async fn poll_okex(
         error.level = tracing::field::Empty,
         error.message = tracing::field::Empty,
     );
-    let tracker = current_tracker(&mut current_job);
+    let tracker = current_tracker(&current_job);
     shared::tracing::record_error(
         if tracker.attempts >= 4 {
             tracing::Level::ERROR

--- a/hedging/src/lib.rs
+++ b/hedging/src/lib.rs
@@ -9,16 +9,17 @@ mod job;
 mod synth_usd_liability;
 
 use okex_client::OkexClientConfig;
-use shared::pubsub::*;
+use shared::{health::HealthCheckTrigger, pubsub::*};
 
 pub use app::*;
 pub use error::*;
 
 pub async fn run(
+    health_check_trigger: HealthCheckTrigger,
     config: HedgingAppConfig,
     okex_config: OkexClientConfig,
     pubsub_cfg: PubSubConfig,
 ) -> Result<(), HedgingError> {
-    HedgingApp::run(config, okex_config, pubsub_cfg).await?;
+    HedgingApp::run(health_check_trigger, config, okex_config, pubsub_cfg).await?;
     Ok(())
 }

--- a/hedging/tests/hedging.rs
+++ b/hedging/tests/hedging.rs
@@ -3,7 +3,7 @@ use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use serial_test::serial;
 
-use std::{env, fs, pin::Pin};
+use std::{env, fs};
 
 use okex_client::*;
 use shared::{payload::*, pubsub::*};
@@ -33,7 +33,7 @@ fn okex_client_config() -> OkexClientConfig {
 }
 
 async fn expect_exposure_between(
-    stream: &mut Pin<Box<dyn Stream<Item = Envelope<OkexBtcUsdSwapPositionPayload>> + Send>>,
+    mut stream: impl Stream<Item = Envelope<OkexBtcUsdSwapPositionPayload>> + Unpin,
     lower: Decimal,
     upper: Decimal,
 ) {
@@ -49,7 +49,7 @@ async fn expect_exposure_between(
 }
 
 async fn expect_exposure_below(
-    stream: &mut Pin<Box<dyn Stream<Item = Envelope<OkexBtcUsdSwapPositionPayload>> + Send>>,
+    mut stream: impl Stream<Item = Envelope<OkexBtcUsdSwapPositionPayload>> + Unpin,
     expected: Decimal,
 ) {
     let mut passed = false;
@@ -64,7 +64,7 @@ async fn expect_exposure_below(
 }
 
 async fn expect_exposure_equal(
-    stream: &mut Pin<Box<dyn Stream<Item = Envelope<OkexBtcUsdSwapPositionPayload>> + Send>>,
+    mut stream: impl Stream<Item = Envelope<OkexBtcUsdSwapPositionPayload>> + Unpin,
     expected: Decimal,
 ) {
     let mut passed = false;

--- a/hedging/tests/hedging.rs
+++ b/hedging/tests/hedging.rs
@@ -99,7 +99,9 @@ async fn hedging() -> anyhow::Result<()> {
         .await?;
 
     tokio::spawn(async move {
+        let (_, recv) = futures::channel::mpsc::unbounded();
         HedgingApp::run(
+            recv,
             HedgingAppConfig {
                 pg_con,
                 migrate_on_start: true,

--- a/price-server/src/app/mod.rs
+++ b/price-server/src/app/mod.rs
@@ -4,7 +4,7 @@ use chrono::Duration;
 use futures::stream::StreamExt;
 use tracing::{info_span, instrument, Instrument};
 
-use shared::{payload::OkexBtcUsdSwapPricePayload, pubsub::*};
+use shared::{health::HealthCheckTrigger, payload::OkexBtcUsdSwapPricePayload, pubsub::*};
 
 use super::exchange_price_cache::ExchangePriceCache;
 
@@ -18,6 +18,7 @@ pub struct PriceApp {
 
 impl PriceApp {
     pub async fn run(
+        health_check_trigger: HealthCheckTrigger,
         fee_calc_cfg: FeeCalculatorConfig,
         pubsub_cfg: PubSubConfig,
     ) -> Result<Self, PriceAppError> {

--- a/price-server/src/exchange_price_cache.rs
+++ b/price-server/src/exchange_price_cache.rs
@@ -110,7 +110,7 @@ impl ExchangePriceCacheInner {
     fn latest_tick(&self) -> Result<BtcSatTick, ExchangePriceCacheError> {
         if let Some(ref tick) = self.tick {
             if tick.timestamp.duration_since() > self.stale_after {
-                return Err(ExchangePriceCacheError::StalePrice(tick.timestamp.clone()));
+                return Err(ExchangePriceCacheError::StalePrice(tick.timestamp));
             }
             return Ok(tick.clone());
         }

--- a/price-server/src/lib.rs
+++ b/price-server/src/lib.rs
@@ -7,7 +7,7 @@ mod exchange_price_cache;
 mod fee_calculator;
 mod server;
 
-use shared::pubsub::PubSubConfig;
+use shared::{health::HealthCheckTrigger, pubsub::PubSubConfig};
 
 use app::PriceApp;
 pub use exchange_price_cache::ExchangePriceCacheError;
@@ -15,11 +15,12 @@ pub use fee_calculator::FeeCalculatorConfig;
 pub use server::*;
 
 pub async fn run(
+    health_check_trigger: HealthCheckTrigger,
     server_config: PriceServerConfig,
     fee_calc_cfg: FeeCalculatorConfig,
     pubsub_cfg: PubSubConfig,
 ) -> Result<(), PriceServerError> {
-    let app = PriceApp::run(fee_calc_cfg, pubsub_cfg).await?;
+    let app = PriceApp::run(health_check_trigger, fee_calc_cfg, pubsub_cfg).await?;
 
     server::start(server_config, app).await?;
 

--- a/price-server/src/server/mod.rs
+++ b/price-server/src/server/mod.rs
@@ -29,14 +29,14 @@ pub struct Price {
 impl PriceService for Price {
     #[instrument(skip_all,
         fields(amount_in_satoshis = request.get_ref().amount_in_satoshis,
-               error, error.message),
+               error, error.level, error.message),
         err
     )]
     async fn get_cents_from_sats_for_immediate_buy(
         &self,
         request: Request<GetCentsFromSatsForImmediateBuyRequest>,
     ) -> Result<Response<GetCentsFromSatsForImmediateBuyResponse>, Status> {
-        shared::tracing::record_error(|| async move {
+        shared::tracing::record_error(tracing::Level::ERROR, || async move {
             extract_tracing(&request);
 
             let req = request.into_inner();
@@ -53,14 +53,14 @@ impl PriceService for Price {
 
     #[instrument(skip_all,
         fields(amount_in_satoshis = request.get_ref().amount_in_satoshis,
-               error, error.message),
+               error, error.level, error.message),
         err
      )]
     async fn get_cents_from_sats_for_immediate_sell(
         &self,
         request: Request<GetCentsFromSatsForImmediateSellRequest>,
     ) -> Result<Response<GetCentsFromSatsForImmediateSellResponse>, Status> {
-        shared::tracing::record_error(|| async move {
+        shared::tracing::record_error(tracing::Level::ERROR, || async move {
             extract_tracing(&request);
 
             let req = request.into_inner();
@@ -78,14 +78,14 @@ impl PriceService for Price {
     #[instrument(skip_all,
         fields(amount_in_satoshis = request.get_ref().amount_in_satoshis,
                 time_in_seconds = request.get_ref().time_in_seconds,
-                error, error.message),
+                error, error.level, error.message),
         err
     )]
     async fn get_cents_from_sats_for_future_buy(
         &self,
         request: Request<GetCentsFromSatsForFutureBuyRequest>,
     ) -> Result<Response<GetCentsFromSatsForFutureBuyResponse>, Status> {
-        shared::tracing::record_error(|| async move {
+        shared::tracing::record_error(tracing::Level::ERROR, || async move {
             extract_tracing(&request);
 
             let req = request.into_inner();
@@ -103,14 +103,14 @@ impl PriceService for Price {
     #[instrument(skip_all,
         fields(amount_in_satoshis = request.get_ref().amount_in_satoshis,
                 time_in_seconds = request.get_ref().time_in_seconds,
-                error, error.message),
+                error, error.level, error.message),
         err
     )]
     async fn get_cents_from_sats_for_future_sell(
         &self,
         request: Request<GetCentsFromSatsForFutureSellRequest>,
     ) -> Result<Response<GetCentsFromSatsForFutureSellResponse>, Status> {
-        shared::tracing::record_error(|| async move {
+        shared::tracing::record_error(tracing::Level::ERROR, || async move {
             extract_tracing(&request);
 
             let req = request.into_inner();
@@ -127,14 +127,14 @@ impl PriceService for Price {
 
     #[instrument(skip_all,
         fields(amount_in_cents = request.get_ref().amount_in_cents,
-            error, error.message),
+            error, error.level, error.message),
         err
     )]
     async fn get_sats_from_cents_for_immediate_buy(
         &self,
         request: Request<GetSatsFromCentsForImmediateBuyRequest>,
     ) -> Result<Response<GetSatsFromCentsForImmediateBuyResponse>, Status> {
-        shared::tracing::record_error(|| async move {
+        shared::tracing::record_error(tracing::Level::ERROR, || async move {
             extract_tracing(&request);
 
             let req = request.into_inner();
@@ -152,14 +152,14 @@ impl PriceService for Price {
 
     #[instrument(skip_all,
         fields(amount_in_cents = request.get_ref().amount_in_cents,
-            error, error.message),
+            error, error.level, error.message),
         err
     )]
     async fn get_sats_from_cents_for_immediate_sell(
         &self,
         request: Request<GetSatsFromCentsForImmediateSellRequest>,
     ) -> Result<Response<GetSatsFromCentsForImmediateSellResponse>, Status> {
-        shared::tracing::record_error(|| async move {
+        shared::tracing::record_error(tracing::Level::ERROR, || async move {
             extract_tracing(&request);
 
             let req = request.into_inner();
@@ -178,14 +178,14 @@ impl PriceService for Price {
     #[instrument(skip_all,
         fields(amount_in_cents = request.get_ref().amount_in_cents,
                 time_in_seconds = request.get_ref().time_in_seconds,
-                error, error.message),
+                error, error.level, error.message),
         err
     )]
     async fn get_sats_from_cents_for_future_buy(
         &self,
         request: Request<GetSatsFromCentsForFutureBuyRequest>,
     ) -> Result<Response<GetSatsFromCentsForFutureBuyResponse>, Status> {
-        shared::tracing::record_error(|| async move {
+        shared::tracing::record_error(tracing::Level::ERROR, || async move {
             extract_tracing(&request);
 
             let req = request.into_inner();
@@ -204,14 +204,14 @@ impl PriceService for Price {
     #[instrument(skip_all,
         fields(amount_in_cents = request.get_ref().amount_in_cents,
                 time_in_seconds = request.get_ref().time_in_seconds,
-                error, error.message),
+                error, error.level, error.message),
         err
     )]
     async fn get_sats_from_cents_for_future_sell(
         &self,
         request: Request<GetSatsFromCentsForFutureSellRequest>,
     ) -> Result<Response<GetSatsFromCentsForFutureSellResponse>, Status> {
-        shared::tracing::record_error(|| async move {
+        shared::tracing::record_error(tracing::Level::ERROR, || async move {
             extract_tracing(&request);
 
             let req = request.into_inner();
@@ -227,12 +227,12 @@ impl PriceService for Price {
         .await
     }
 
-    #[instrument(skip_all, fields(error, error.message) err)]
+    #[instrument(skip_all, fields(error, error.level, error.message) err)]
     async fn get_cents_per_sats_exchange_mid_rate(
         &self,
         request: Request<GetCentsPerSatsExchangeMidRateRequest>,
     ) -> Result<Response<GetCentsPerSatsExchangeMidRateResponse>, Status> {
-        shared::tracing::record_error(|| async move {
+        shared::tracing::record_error(tracing::Level::ERROR, || async move {
             extract_tracing(&request);
 
             let ratio_in_cents_per_satoshis =

--- a/price-server/tests/price_app.rs
+++ b/price-server/tests/price_app.rs
@@ -27,7 +27,9 @@ async fn price_app() -> anyhow::Result<()> {
     let subscriber = Subscriber::new(config.clone()).await?;
     let mut stream = subscriber.subscribe::<OkexBtcUsdSwapPricePayload>().await?;
 
+    let (_, recv) = futures::channel::mpsc::unbounded();
     let app = PriceApp::run(
+        recv,
         FeeCalculatorConfig {
             base_fee_rate: dec!(0.001),
             immediate_fee_rate: dec!(0.01),

--- a/shared/src/health.rs
+++ b/shared/src/health.rs
@@ -1,0 +1,5 @@
+use futures::channel::{mpsc::*, oneshot};
+
+pub type HealthCheckResponse = Result<(), String>;
+pub type HealthCheckTrigger = UnboundedReceiver<oneshot::Sender<HealthCheckResponse>>;
+pub type HealthChecker = UnboundedSender<oneshot::Sender<HealthCheckResponse>>;

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(feature = "fail-on-warnings", deny(warnings))]
 #![cfg_attr(feature = "fail-on-warnings", deny(clippy::all))]
 
+pub mod health;
 pub mod macros;
 pub mod payload;
 pub mod pubsub;

--- a/shared/src/pubsub/message.rs
+++ b/shared/src/pubsub/message.rs
@@ -53,9 +53,9 @@ impl Default for MessageMetadata {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct Envelope<P: MessagePayload> {
+pub struct Envelope<P: MessagePayload + Clone> {
     pub meta: MessageMetadata,
     pub payload_type: String,
     #[serde(bound = "P: DeserializeOwned")]

--- a/shared/src/pubsub/subscriber.rs
+++ b/shared/src/pubsub/subscriber.rs
@@ -1,12 +1,15 @@
 use fred::{clients::SubscriberClient, prelude::*};
-use futures::stream::{Stream, StreamExt};
+use futures::{channel::mpsc::*, stream::StreamExt, SinkExt};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
-use super::config::*;
-use super::error::SubscriberError;
-use super::message::*;
+use super::{config::*, error::SubscriberError, message::*};
+use crate::time::TimeStamp;
 
 pub struct Subscriber {
     client: SubscriberClient,
+    last_msg_timestamp: Arc<RwLock<Option<TimeStamp>>>,
+    timestamp_sender: UnboundedSender<TimeStamp>,
 }
 
 impl Subscriber {
@@ -18,29 +21,55 @@ impl Subscriber {
             .await
             .map_err(SubscriberError::InitialConnection)?;
         let _ = client.manage_subscriptions();
-        Ok(Self { client })
+        let last_msg_timestamp = Arc::new(RwLock::new(None));
+        let ts = Arc::clone(&last_msg_timestamp);
+        let (timestamp_sender, mut rcv) = unbounded();
+        tokio::spawn(async move {
+            while let Some(timestamp) = rcv.next().await {
+                *ts.write().await = Some(timestamp);
+            }
+        });
+        Ok(Self {
+            client,
+            last_msg_timestamp,
+            timestamp_sender,
+        })
+    }
+
+    pub async fn time_since_last_msg(&self) -> Option<chrono::Duration> {
+        let last_msg_timestamp = self.last_msg_timestamp.read().await;
+        last_msg_timestamp.map(|ts| ts.duration_since())
     }
 
     pub async fn subscribe<M: MessagePayload>(
         &self,
-    ) -> Result<std::pin::Pin<Box<dyn Stream<Item = Envelope<M>> + Send>>, SubscriberError> {
+    ) -> Result<Receiver<Envelope<M>>, SubscriberError> {
         let message_stream = self.client.on_message();
         self.client
             .subscribe(<M as MessagePayload>::channel())
             .await?;
-        Ok(Box::pin(message_stream.filter_map(
-            |(channel, value)| async move {
-                if channel == <M as MessagePayload>::channel() {
-                    if let RedisValue::String(v) = value {
-                        if let Ok(msg) = serde_json::from_str::<Envelope<M>>(&v) {
-                            if msg.payload_type == <M as MessagePayload>::message_type() {
-                                return Some(msg);
+        let (snd, recv) = channel(100);
+        tokio::spawn(
+            message_stream
+                .filter_map(|(channel, value)| async move {
+                    if channel == <M as MessagePayload>::channel() {
+                        if let RedisValue::String(v) = value {
+                            if let Ok(msg) = serde_json::from_str::<Envelope<M>>(&v) {
+                                if msg.payload_type == <M as MessagePayload>::message_type() {
+                                    return Some(Ok(msg));
+                                }
                             }
                         }
                     }
-                }
-                None
-            },
-        )))
+                    None
+                })
+                .forward(
+                    self.timestamp_sender
+                        .clone()
+                        .with(|msg: Envelope<M>| async move { Ok(msg.meta.published_at) })
+                        .fanout(snd),
+                ),
+        );
+        Ok(recv)
     }
 }

--- a/shared/src/time.rs
+++ b/shared/src/time.rs
@@ -1,7 +1,7 @@
 use chrono::{prelude::*, Duration};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct TimeStamp(#[serde(with = "chrono::serde::ts_seconds")] DateTime<Utc>);
 impl TimeStamp {

--- a/shared/src/tracing.rs
+++ b/shared/src/tracing.rs
@@ -24,16 +24,18 @@ pub async fn record_error<
     F: FnOnce() -> R,
     R: std::future::Future<Output = Result<T, E>>,
 >(
+    level: tracing::Level,
     func: F,
 ) -> Result<T, E> {
     let result = func().await;
     if let Err(ref e) = result {
-        insert_error_fields(e);
+        insert_error_fields(level, e);
     }
     result
 }
 
-pub fn insert_error_fields(error: impl std::fmt::Display) {
+pub fn insert_error_fields(level: tracing::Level, error: impl std::fmt::Display) {
     Span::current().record("error", &tracing::field::display("true"));
+    Span::current().record("error.level", &tracing::field::display(level));
     Span::current().record("error.message", &tracing::field::display(error));
 }

--- a/shared/tests/pubsub.rs
+++ b/shared/tests/pubsub.rs
@@ -20,6 +20,7 @@ async fn pubsub() -> anyhow::Result<()> {
     };
     let publisher = Publisher::new(config.clone()).await?;
     let subscriber = Subscriber::new(config).await?;
+    assert!(subscriber.time_since_last_msg().await.is_none());
     let mut stream = subscriber.subscribe::<TestMessage>().await?;
     let msg = TestMessage {
         test: "test".to_string(),
@@ -27,6 +28,7 @@ async fn pubsub() -> anyhow::Result<()> {
     };
     publisher.publish(msg.clone()).await?;
     let received = stream.next().await;
+    assert!(subscriber.time_since_last_msg().await.is_some());
     assert_eq!(msg, received.unwrap().payload);
     Ok(())
 }

--- a/user-trades/src/app/config.rs
+++ b/user-trades/src/app/config.rs
@@ -32,7 +32,7 @@ fn default_balance_publish_frequency() -> Duration {
 }
 
 fn default_galoy_poll_frequency() -> Duration {
-    Duration::from_secs(5)
+    Duration::from_secs(8)
 }
 
 fn bool_true() -> bool {

--- a/user-trades/src/job/poll_galoy_transactions.rs
+++ b/user-trades/src/job/poll_galoy_transactions.rs
@@ -13,23 +13,19 @@ use crate::{
     name = "poll_galoy_transactions",
     skip_all,
     err,
-    fields(error, error.message)
+    fields(n_galoy_txs, n_unpaired_txs, n_user_trades)
 )]
 pub(super) async fn execute(
     user_trades: &UserTrades,
     galoy_transactions: &GaloyTransactions,
     galoy: &GaloyClient,
 ) -> Result<bool, UserTradesError> {
-    shared::tracing::record_error(|| async move {
-        let has_more = import_galoy_transactions(galoy_transactions, galoy.clone()).await?;
-        update_user_trades(galoy_transactions, user_trades).await?;
+    let has_more = import_galoy_transactions(galoy_transactions, galoy.clone()).await?;
+    update_user_trades(galoy_transactions, user_trades).await?;
 
-        Ok(has_more)
-    })
-    .await
+    Ok(has_more)
 }
 
-#[instrument(skip_all, err, fields(n_galoy_txs))]
 async fn import_galoy_transactions(
     galoy_transactions: &GaloyTransactions,
     galoy: GaloyClient,
@@ -50,7 +46,6 @@ async fn import_galoy_transactions(
     Ok(transactions.has_more)
 }
 
-#[instrument(skip_all, err, fields(n_unpaired_txs, n_user_trades))]
 async fn update_user_trades(
     galoy_transactions: &GaloyTransactions,
     user_trades: &UserTrades,


### PR DESCRIPTION
This PR has the following improvements:
- add a health check server that listens on port 8080
- generic method (based on channels) for getting health reports from the individual sub components
- adding health reporting from price server and hedging channels that depend on the time the last message was received from redis (to fix the current bug with the redis library reconnecting).

In addition there are some modifications to the tracing code:
- record an `error.level` field in preparation for adding an explicit alert for stablesats when the `level = ERROR`.