### PR TITLE
chore: shared JobExecutor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,6 +475,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
+name = "derive_builder"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2488,6 +2519,7 @@ version = "0.3.5-dev"
 dependencies = [
  "anyhow",
  "chrono",
+ "derive_builder",
  "fred",
  "futures",
  "governor",
@@ -2498,6 +2530,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "sqlx",
+ "sqlxmq",
  "thiserror",
  "tokio",
  "tracing",

--- a/hedging/src/error.rs
+++ b/hedging/src/error.rs
@@ -1,6 +1,9 @@
 use thiserror::Error;
 
-use shared::pubsub::{PublisherError, SubscriberError};
+use shared::{
+    pubsub::{PublisherError, SubscriberError},
+    sqlxmq::JobExecutionError,
+};
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Error, Debug)]
@@ -18,3 +21,5 @@ pub enum HedgingError {
     #[error("HedgingError - OkexClient: {0}")]
     OkexClient(#[from] okex_client::OkexClientError),
 }
+
+impl JobExecutionError for HedgingError {}

--- a/hedging/src/job/adjust_hedge.rs
+++ b/hedging/src/job/adjust_hedge.rs
@@ -6,7 +6,7 @@ use shared::pubsub::CorrelationId;
 
 use crate::{adjustment_action::*, error::*, okex_orders::*, synth_usd_liability::*};
 
-#[instrument(name = "adjust_hedge", skip_all, fields(
+#[instrument(name = "adjust_hedge", skip_all, fields(correlation_id = %correlation_id,
         target_liability, current_position, action, placed_order, client_order_id) err)]
 pub(super) async fn execute(
     correlation_id: CorrelationId,

--- a/hedging/tests/hedging.rs
+++ b/hedging/tests/hedging.rs
@@ -105,7 +105,7 @@ async fn hedging() -> anyhow::Result<()> {
             HedgingAppConfig {
                 pg_con,
                 migrate_on_start: true,
-                okex_poll_frequency: std::time::Duration::from_secs(1),
+                okex_poll_frequency: std::time::Duration::from_secs(2),
             },
             okex_client_config(),
             pubsub_config,

--- a/price-server/src/app/mod.rs
+++ b/price-server/src/app/mod.rs
@@ -168,7 +168,7 @@ impl PriceApp {
         Ok(self.fee_calculator.decrease_by_delayed_fee(sats).floor())
     }
 
-    #[instrument(skip_all, fields(correlation_id, ret, err))]
+    #[instrument(skip_all, fields(correlation_id), ret, err)]
     pub async fn get_cents_per_sat_exchange_mid_rate(&self) -> Result<f64, PriceAppError> {
         let cents_per_sat = self.price_cache.latest_tick().await?.mid_price_of_one_sat();
         Ok(f64::try_from(cents_per_sat)?)

--- a/price-server/src/server/mod.rs
+++ b/price-server/src/server/mod.rs
@@ -227,7 +227,7 @@ impl PriceService for Price {
         .await
     }
 
-    #[instrument(skip_all, fields(error, error.level, error.message) err)]
+    #[instrument(skip_all, fields(error, error.level, error.message), err)]
     async fn get_cents_per_sats_exchange_mid_rate(
         &self,
         request: Request<GetCentsPerSatsExchangeMidRateRequest>,

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -14,6 +14,7 @@ fail-on-warnings = []
 [dependencies]
 # setting default-features = false to not include vulnerable time crate
 chrono = { version = "0.4", features = ["clock", "serde"], default-features = false }
+derive_builder = "0.11.2"
 fred = { version = "5.2.0", features = ["subscriber-client"] }
 futures = "0.3.24"
 opentelemetry = "0.18.0"
@@ -21,6 +22,9 @@ rust_decimal = "1.26.1"
 rust_decimal_macros = "1.26.1"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"
+serde_with = "2.0.1"
+sqlx = { version = "0.6", features = [ "offline", "runtime-tokio-rustls", "postgres", "decimal", "uuid", "chrono", "json" ] }
+sqlxmq = { version = "0.4.1", default-features = false, features = [ "runtime-tokio-rustls" ] }
 thiserror = "1.0.36"
 tokio = "1.20.1"
 tracing = "0.1.36"
@@ -28,7 +32,6 @@ tracing-opentelemetry = "0.18.0"
 uuid = { version = "1.1.2", features = ["v4", "serde"] }
 governor = "0.5.0"
 lazy_static = "1.4.0"
-serde_with = "2.0.1"
 
 [dev-dependencies]
 anyhow = "1.0.65"

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -5,6 +5,7 @@ pub mod health;
 pub mod macros;
 pub mod payload;
 pub mod pubsub;
+pub mod sqlxmq;
 pub mod time;
 pub mod tracing;
 

--- a/shared/src/sqlxmq.rs
+++ b/shared/src/sqlxmq.rs
@@ -1,0 +1,186 @@
+use derive_builder::Builder;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use sqlxmq::CurrentJob;
+use tracing::{instrument, Span};
+
+use std::{collections::HashMap, time::Duration};
+
+pub trait JobExecutionError: std::fmt::Display + From<sqlx::Error> {}
+
+#[derive(Builder)]
+#[builder(pattern = "owned")]
+pub struct JobExecutor<'a> {
+    job: &'a mut CurrentJob,
+    #[builder(default = "4")]
+    warn_retries: u32,
+    #[builder(default = "5")]
+    max_attempts: u32,
+    #[builder(default = "Duration::from_secs(60)")]
+    max_retry_delay: Duration,
+}
+
+impl<'a> JobExecutor<'a> {
+    pub fn builder(job: &'a mut CurrentJob) -> JobExecutorBuilder<'a> {
+        JobExecutorBuilder::default().job(job)
+    }
+
+    #[instrument(name = "execute_job", skip_all, fields(
+            job_id, job_name, error, error.level, error.message, attempt, last_attempt
+    ))]
+    pub async fn execute<T, E, R, F>(mut self, func: F) -> Result<T, E>
+    where
+        T: DeserializeOwned + Serialize,
+        E: JobExecutionError,
+        R: std::future::Future<Output = Result<T, E>>,
+        F: FnOnce(Option<T>) -> R,
+    {
+        let mut data = JobData::<T>::from_raw_payload(self.job.raw_json()).unwrap();
+        let completed = self.checkpoint_attempt(&mut data).await?;
+        let result = func(data.data).await;
+        if let Err(ref e) = result {
+            self.handle_error(data.job_meta, e).await;
+        }
+        if !completed {
+            self.job.complete().await?;
+        }
+        result
+    }
+
+    async fn handle_error<E: JobExecutionError>(&mut self, meta: JobMeta, error: &E) {
+        Span::current().record("error", &tracing::field::display("true"));
+        Span::current().record("error.message", &tracing::field::display(&error));
+        if meta.attempts <= self.warn_retries {
+            Span::current().record(
+                "error.level",
+                &tracing::field::display(tracing::Level::WARN),
+            );
+        } else {
+            Span::current().record(
+                "error.level",
+                &tracing::field::display(tracing::Level::ERROR),
+            );
+        }
+    }
+
+    async fn checkpoint_attempt<T: Serialize>(
+        &mut self,
+        data: &mut JobData<T>,
+    ) -> Result<bool, sqlx::Error> {
+        let span = Span::current();
+
+        crate::tracing::inject_tracing_data(&span, &data.tracing_data);
+
+        data.job_meta.attempts += 1;
+        data.tracing_data = crate::tracing::extract_tracing_data();
+
+        span.record("job_id", &tracing::field::display(self.job.id()));
+        span.record("job_name", &tracing::field::display(self.job.name()));
+        span.record("attempt", &tracing::field::display(data.job_meta.attempts));
+
+        let mut checkpoint =
+            sqlxmq::Checkpoint::new_keep_alive(data.job_meta.wait_till_next_attempt);
+
+        data.job_meta.wait_till_next_attempt = self
+            .max_retry_delay
+            .min(data.job_meta.wait_till_next_attempt * 2);
+        if data.job_meta.attempts < self.max_attempts {
+            checkpoint.set_extra_retries(1);
+        }
+
+        checkpoint.set_json(&data).expect("Couldn't update tracker");
+        self.job.checkpoint(&checkpoint).await?;
+
+        if data.job_meta.attempts >= self.max_attempts {
+            span.record("last_attempt", &tracing::field::display(true));
+            self.job.complete().await?;
+            Ok(true)
+        } else {
+            span.record("last_attempt", &tracing::field::display(false));
+            Ok(false)
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+struct JobData<T> {
+    #[serde(rename = "_job_meta", default)]
+    job_meta: JobMeta,
+    #[serde(flatten)]
+    data: Option<T>,
+    #[serde(flatten)]
+    tracing_data: HashMap<String, String>,
+}
+
+impl<'a, T: Deserialize<'a>> JobData<T> {
+    pub fn from_raw_payload(payload: Option<&'a str>) -> Result<Self, serde_json::Error> {
+        if let Some(payload) = payload {
+            serde_json::from_str(payload)
+        } else {
+            Ok(Self {
+                job_meta: JobMeta::default(),
+                data: None,
+                tracing_data: HashMap::new(),
+            })
+        }
+    }
+}
+
+#[serde_with::serde_as]
+#[derive(Serialize, Deserialize)]
+struct JobMeta {
+    attempts: u32,
+    #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    wait_till_next_attempt: Duration,
+}
+impl Default for JobMeta {
+    fn default() -> Self {
+        Self {
+            attempts: 0,
+            wait_till_next_attempt: Duration::from_secs(1),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Deserialize)]
+    struct DummyData {
+        value: String,
+    }
+
+    #[test]
+    fn from_raw() {
+        let json = r#"{
+            "_job_meta": {
+                "attempts": 1,
+                "wait_till_next_attempt": 1
+            }
+        }"#;
+        let job_data: JobData<DummyData> = JobData::from_raw_payload(Some(json)).unwrap();
+        assert!(job_data.job_meta.attempts == 1);
+        assert!(job_data.data.is_none());
+        assert!(job_data.tracing_data.is_empty());
+
+        let json = r#"{
+            "value": "test"
+        }"#;
+        let job_data: JobData<DummyData> = JobData::from_raw_payload(Some(json)).unwrap();
+        assert!(job_data.job_meta.attempts == 0);
+        assert_eq!(job_data.data.unwrap().value, "test");
+        assert!(job_data.tracing_data.is_empty());
+
+        let json = r#"{
+            "_job_meta": {
+                "attempts": 2,
+                "wait_till_next_attempt": 1
+            },
+            "header": "value"
+        }"#;
+        let job_data: JobData<DummyData> = JobData::from_raw_payload(Some(json)).unwrap();
+        assert!(job_data.job_meta.attempts == 2);
+        assert!(job_data.data.is_none());
+        assert_eq!(job_data.tracing_data.get("header").unwrap(), "value");
+    }
+}

--- a/user-trades/src/error.rs
+++ b/user-trades/src/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use shared::pubsub::PublisherError;
+use shared::{pubsub::PublisherError, sqlxmq::JobExecutionError};
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Error, Debug)]
@@ -14,3 +14,5 @@ pub enum UserTradesError {
     #[error("UserTradesError - GaloyClient: {0}")]
     GaloyClient(#[from] galoy_client::GaloyClientError),
 }
+
+impl JobExecutionError for UserTradesError {}

--- a/user-trades/src/job/mod.rs
+++ b/user-trades/src/job/mod.rs
@@ -2,7 +2,7 @@ mod poll_galoy_transactions;
 
 use rust_decimal_macros::dec;
 use sqlxmq::{job, CurrentJob, JobBuilder, JobRegistry, OwnedHandle};
-use tracing::{info_span, instrument, Instrument, Span};
+use tracing::instrument;
 use uuid::{uuid, Uuid};
 
 use galoy_client::GaloyClient;


### PR DESCRIPTION
This PR introduces the `JobExecutor` that should unify handling (tracing, retries, error reporting etc) of sqlxmq jobs across crates.