### PR TITLE
fix: galoy client error return

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,7 @@ dependencies = [
  "rust_decimal",
  "rust_decimal_macros",
  "serde",
+ "serde_json",
  "thiserror",
  "tokio",
  "tracing",

--- a/galoy-client/Cargo.toml
+++ b/galoy-client/Cargo.toml
@@ -12,6 +12,7 @@ futures = "0.3.23"
 graphql_client = {version = "0.11.0", features = ["reqwest"]}
 reqwest = { version = "0.11.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0.145", features = ["derive"] }
+serde_json = "1.0.85"
 
 thiserror = "1.0.37"
 chrono = { version = "0.4", features = ["clock", "serde"], default-features = false }

--- a/galoy-client/src/client/convert.rs
+++ b/galoy-client/src/client/convert.rs
@@ -124,3 +124,23 @@ impl TryFrom<stablesats_transactions_list::ResponseData> for GaloyTransactions {
         })
     }
 }
+
+impl From<StablesatsLoginErrors> for InnerError {
+    fn from(err: StablesatsLoginErrors) -> Self {
+        InnerError {
+            message: err.message,
+            path: err.path,
+        }
+    }
+}
+
+impl From<graphql_client::Error> for TopLevelError {
+    fn from(err: graphql_client::Error) -> Self {
+        TopLevelError {
+            message: err.message,
+            path: err.path,
+            location: err.locations,
+            extensions: err.extensions,
+        }
+    }
+}

--- a/galoy-client/src/client/convert.rs
+++ b/galoy-client/src/client/convert.rs
@@ -9,11 +9,9 @@ impl TryFrom<stablesats_wallets::ResponseData> for WalletBalances {
     type Error = GaloyClientError;
 
     fn try_from(response: stablesats_wallets::ResponseData) -> Result<Self, Self::Error> {
-        let me = response.me.ok_or_else(|| GaloyClientError::GraphQLApi {
+        let me = response.me.ok_or_else(|| GaloyClientError::GraphQLNested {
             message: "Empty `me` in response data".to_string(),
-            path: PathString(None),
-            location: None,
-            extensions: None,
+            path: None,
         })?;
 
         let default_account = me.default_account;
@@ -40,11 +38,9 @@ impl TryFrom<stablesats_wallets::ResponseData> for WalletBalances {
         if let (Some(btc), Some(usd)) = (btc, usd) {
             Ok(Self { btc, usd })
         } else {
-            Err(GaloyClientError::GraphQLApi {
+            Err(GaloyClientError::GraphQLNested {
                 message: "Missing `btc` or `usd` in response data".to_string(),
-                path: PathString(None),
-                location: None,
-                extensions: None,
+                path: None,
             })
         }
     }
@@ -54,11 +50,9 @@ impl TryFrom<stablesats_wallets::ResponseData> for WalletId {
     type Error = GaloyClientError;
 
     fn try_from(response: stablesats_wallets::ResponseData) -> Result<Self, Self::Error> {
-        let me = response.me.ok_or_else(|| GaloyClientError::GraphQLApi {
+        let me = response.me.ok_or_else(|| GaloyClientError::GraphQLNested {
             message: "Empty `me` in response data".to_string(),
-            path: PathString(None),
-            location: None,
-            extensions: None,
+            path: None,
         })?;
 
         let default_account = me.default_account;
@@ -72,11 +66,9 @@ impl TryFrom<stablesats_wallets::ResponseData> for WalletId {
             }
         }
 
-        let btc_id = btc_id.ok_or_else(|| GaloyClientError::GraphQLApi {
+        let btc_id = btc_id.ok_or_else(|| GaloyClientError::GraphQLNested {
             message: "Missing `btc id` in response data".to_string(),
-            path: PathString(None),
-            location: None,
-            extensions: None,
+            path: None,
         })?;
 
         Ok(btc_id)
@@ -87,31 +79,25 @@ impl TryFrom<stablesats_transactions_list::ResponseData> for GaloyTransactions {
     type Error = GaloyClientError;
 
     fn try_from(response: stablesats_transactions_list::ResponseData) -> Result<Self, Self::Error> {
-        let me = response.me.ok_or_else(|| GaloyClientError::GraphQLApi {
+        let me = response.me.ok_or_else(|| GaloyClientError::GraphQLNested {
             message: "Empty `me` in response data".to_string(),
-            path: PathString(None),
-            location: None,
-            extensions: None,
+            path: None,
         })?;
 
         let transactions =
             me.default_account
                 .transactions
-                .ok_or_else(|| GaloyClientError::GraphQLApi {
+                .ok_or_else(|| GaloyClientError::GraphQLNested {
                     message: "Empty `transactions` in response data".to_string(),
-                    path: PathString(None),
-                    location: None,
-                    extensions: None,
+                    path: None,
                 })?;
 
         let page_info = transactions.page_info;
         let edges = transactions
             .edges
-            .ok_or_else(|| GaloyClientError::GraphQLApi {
+            .ok_or_else(|| GaloyClientError::GraphQLNested {
                 message: "Empty `transaction edges` in response data".to_string(),
-                path: PathString(None),
-                location: None,
-                extensions: None,
+                path: None,
             })?;
         let list = edges
             .into_iter()

--- a/galoy-client/src/client/graphql/schema.graphql
+++ b/galoy-client/src/client/graphql/schema.graphql
@@ -59,6 +59,11 @@ type BTCWallet implements Wallet {
   id: ID!
 
   """
+  An unconfirmed incoming onchain balance.
+  """
+  pendingIncomingBalance: SignedAmount!
+
+  """
   A list of BTC transactions associated with this wallet.
   """
   transactions(
@@ -197,6 +202,7 @@ input DeviceNotificationTokenCreateInput {
 }
 
 interface Error {
+  code: String
   message: String!
   path: [String]
 }
@@ -219,10 +225,21 @@ type Globals {
   lightningAddressDomainAliases: [String!]!
 
   """
+  Which network (mainnet, testnet, regtest, signet) this instance is running on.
+  """
+  network: Network!
+
+  """
   A list of public keys for the running lightning nodes.
   This can be used to know if an invoice belongs to one of our nodes.
   """
   nodesIds: [String!]!
+}
+
+type GraphQLApplicationError implements Error {
+  code: String
+  message: String!
+  path: [String]
 }
 
 """
@@ -230,10 +247,7 @@ Hex-encoded string of 32 bytes
 """
 scalar Hex32Bytes
 
-union InitiationVia =
-    InitiationViaIntraLedger
-  | InitiationViaLn
-  | InitiationViaOnChain
+union InitiationVia = InitiationViaIntraLedger | InitiationViaLn | InitiationViaOnChain
 
 type InitiationViaIntraLedger {
   counterPartyUsername: Username
@@ -246,19 +260,6 @@ type InitiationViaLn {
 
 type InitiationViaOnChain {
   address: OnChainAddress!
-}
-
-type InputError implements Error {
-  code: InputErrorCode!
-  message: String!
-  path: [String]
-}
-
-enum InputErrorCode {
-  INVALID_INPUT
-  VALUE_NOT_ALLOWED
-  VALUE_TOO_LONG
-  VALUE_TOO_SHORT
 }
 
 input IntraLedgerPaymentSendInput {
@@ -572,18 +573,14 @@ type Mutation {
   not use onchain/lightning. Returns payment status (success,
   failed, pending, already_paid).
   """
-  intraLedgerPaymentSend(
-    input: IntraLedgerPaymentSendInput!
-  ): PaymentSendPayload!
+  intraLedgerPaymentSend(input: IntraLedgerPaymentSendInput!): PaymentSendPayload!
 
   """
   Actions a payment which is internal to the ledger e.g. it does
   not use onchain/lightning. Returns payment status (success,
   failed, pending, already_paid).
   """
-  intraLedgerUsdPaymentSend(
-    input: IntraLedgerUsdPaymentSendInput!
-  ): PaymentSendPayload!
+  intraLedgerUsdPaymentSend(input: IntraLedgerUsdPaymentSendInput!): PaymentSendPayload!
 
   """
   Returns a lightning invoice for an associated wallet.
@@ -614,9 +611,7 @@ type Mutation {
   Can be used to receive any supported currency value (currently USD or BTC).
   Expires after 24 hours.
   """
-  lnNoAmountInvoiceCreate(
-    input: LnNoAmountInvoiceCreateInput!
-  ): LnNoAmountInvoicePayload!
+  lnNoAmountInvoiceCreate(input: LnNoAmountInvoiceCreateInput!): LnNoAmountInvoicePayload!
 
   """
   Returns a lightning invoice for an associated wallet.
@@ -626,18 +621,14 @@ type Mutation {
   lnNoAmountInvoiceCreateOnBehalfOfRecipient(
     input: LnNoAmountInvoiceCreateOnBehalfOfRecipientInput!
   ): LnNoAmountInvoicePayload!
-  lnNoAmountInvoiceFeeProbe(
-    input: LnNoAmountInvoiceFeeProbeInput!
-  ): SatAmountPayload!
+  lnNoAmountInvoiceFeeProbe(input: LnNoAmountInvoiceFeeProbeInput!): SatAmountPayload!
 
   """
   Pay a lightning invoice using a balance from a wallet which is owned by the account of the current user.
   Provided wallet must be BTC and must have sufficient balance to cover amount specified in mutation request.
   Returns payment status (success, failed, pending, already_paid).
   """
-  lnNoAmountInvoicePaymentSend(
-    input: LnNoAmountInvoicePaymentInput!
-  ): PaymentSendPayload!
+  lnNoAmountInvoicePaymentSend(input: LnNoAmountInvoicePaymentInput!): PaymentSendPayload!
   lnNoAmountUsdInvoiceFeeProbe(
     input: LnNoAmountUsdInvoiceFeeProbeInput!
   ): CentAmountPayload!
@@ -669,12 +660,8 @@ type Mutation {
     input: LnUsdInvoiceCreateOnBehalfOfRecipientInput!
   ): LnInvoicePayload!
   lnUsdInvoiceFeeProbe(input: LnUsdInvoiceFeeProbeInput!): SatAmountPayload!
-  onChainAddressCreate(
-    input: OnChainAddressCreateInput!
-  ): OnChainAddressPayload!
-  onChainAddressCurrent(
-    input: OnChainAddressCurrentInput!
-  ): OnChainAddressPayload!
+  onChainAddressCreate(input: OnChainAddressCreateInput!): OnChainAddressPayload!
+  onChainAddressCurrent(input: OnChainAddressCurrentInput!): OnChainAddressPayload!
   onChainPaymentSend(input: OnChainPaymentSendInput!): PaymentSendPayload!
   onChainPaymentSendAll(input: OnChainPaymentSendAllInput!): PaymentSendPayload!
   twoFADelete(input: TwoFADeleteInput!): SuccessPayload!
@@ -682,19 +669,14 @@ type Mutation {
   twoFASave(input: TwoFASaveInput!): SuccessPayload!
   userContactUpdateAlias(
     input: UserContactUpdateAliasInput!
-  ): UserContactUpdateAliasPayload!
-    @deprecated(reason: "will be moved to AccountContact")
+  ): UserContactUpdateAliasPayload! @deprecated(reason: "will be moved to AccountContact")
   userLogin(input: UserLoginInput!): AuthTokenPayload!
   userQuizQuestionUpdateCompleted(
     input: UserQuizQuestionUpdateCompletedInput!
   ): UserQuizQuestionUpdateCompletedPayload!
   userRequestAuthCode(input: UserRequestAuthCodeInput!): SuccessPayload!
-  userUpdateLanguage(
-    input: UserUpdateLanguageInput!
-  ): UserUpdateLanguagePayload!
-  userUpdateUsername(
-    input: UserUpdateUsernameInput!
-  ): UserUpdateUsernamePayload!
+  userUpdateLanguage(input: UserUpdateLanguageInput!): UserUpdateLanguagePayload!
+  userUpdateUsername(input: UserUpdateUsernameInput!): UserUpdateUsernamePayload!
     @deprecated(
       reason: "Username will be moved to @Handle in Accounts. Also SetUsername should be used instead of UpdateUsername to reflect the idempotency of Handles"
     )
@@ -704,6 +686,13 @@ type MyUpdatesPayload {
   errors: [Error!]!
   me: User
   update: UserUpdate
+}
+
+enum Network {
+  mainnet
+  regtest
+  signet
+  testnet
 }
 
 """
@@ -785,21 +774,6 @@ type PageInfo {
   startCursor: String
 }
 
-type PaymentError implements Error {
-  code: PaymentErrorCode!
-  message: String!
-  path: [String]
-}
-
-enum PaymentErrorCode {
-  ACCOUNT_LOCKED
-  INSUFFICIENT_BALANCE
-  INVOICE_PAID
-  LIMIT_EXCEEDED
-  NO_LIQUIDITY
-  NO_ROUTE
-}
-
 scalar PaymentHash
 
 type PaymentSendPayload {
@@ -869,10 +843,7 @@ type PublicWallet {
 }
 
 type Query {
-  accountDefaultWallet(
-    username: Username!
-    walletCurrency: WalletCurrency
-  ): PublicWallet!
+  accountDefaultWallet(username: Username!, walletCurrency: WalletCurrency): PublicWallet!
   btcPrice: Price
   btcPriceList(range: PriceGraphRange!): [PricePoint]
   businessMapMarkers: [MapMarker]
@@ -917,10 +888,7 @@ type SatAmountPayload {
   errors: [Error!]!
 }
 
-union SettlementVia =
-    SettlementViaIntraLedger
-  | SettlementViaLn
-  | SettlementViaOnChain
+union SettlementVia = SettlementViaIntraLedger | SettlementViaLn | SettlementViaOnChain
 
 type SettlementViaIntraLedger {
   """
@@ -1087,6 +1055,11 @@ type UsdWallet implements Wallet {
   accountId: ID!
   balance: SignedAmount!
   id: ID!
+
+  """
+  An unconfirmed incoming onchain balance.
+  """
+  pendingIncomingBalance: SignedAmount!
   transactions(
     """
     Returns the items in the list that come after the specified cursor.
@@ -1168,15 +1141,13 @@ type User {
   """
   List the quiz questions the user may have completed.
   """
-  quizQuestions: [UserQuizQuestion!]!
-    @deprecated(reason: "will be moved to Accounts")
+  quizQuestions: [UserQuizQuestion!]! @deprecated(reason: "will be moved to Accounts")
   twoFAEnabled: Boolean
 
   """
   Optional immutable user friendly identifier.
   """
-  username: Username
-    @deprecated(reason: "will be moved to @Handle in Account and Wallet")
+  username: Username @deprecated(reason: "will be moved to @Handle in Account and Wallet")
 }
 
 type UserContact {
@@ -1284,6 +1255,7 @@ interface Wallet {
   accountId: ID!
   balance: SignedAmount!
   id: ID!
+  pendingIncomingBalance: SignedAmount!
 
   """
   Transactions are ordered anti-chronologically,

--- a/galoy-client/src/client/mod.rs
+++ b/galoy-client/src/client/mod.rs
@@ -85,12 +85,12 @@ impl GaloyClient {
             phone_number,
         )
         .await?;
-        let response_data = response.data.ok_or_else(|| GaloyClientError::GraphQLApi {
-            message: "Empty authentication code response data".to_string(),
-            path: PathString(None),
-            location: None,
-            extensions: None,
-        })?;
+        let response_data = response
+            .data
+            .ok_or_else(|| GaloyClientError::GraphQLNested {
+                message: "Empty authentication code response data".to_string(),
+                path: None,
+            })?;
 
         let auth_code = StablesatsAuthenticationCode::try_from(response_data)?;
 
@@ -117,21 +117,21 @@ impl GaloyClient {
             if let Some(errors) = response.errors {
                 let zeroth_error = errors[0].clone();
 
-                return Err(GaloyClientError::GraphQLApi {
+                return Err(GaloyClientError::GraphQLTopLevel {
                     message: zeroth_error.message,
                     path: zeroth_error.path.into(),
-                    location: zeroth_error.locations,
+                    locations: zeroth_error.locations,
                     extensions: zeroth_error.extensions,
                 });
             }
         }
 
-        let response_data = response.data.ok_or_else(|| GaloyClientError::GraphQLApi {
-            message: "Empty `data` in response".to_string(),
-            path: PathString(None),
-            location: None,
-            extensions: None,
-        })?;
+        let response_data = response
+            .data
+            .ok_or_else(|| GaloyClientError::GraphQLNested {
+                message: "Empty `data` in response".to_string(),
+                path: None,
+            })?;
 
         let auth_token = StablesatsAuthToken::try_from(response_data)?;
 
@@ -154,21 +154,19 @@ impl GaloyClient {
             if let Some(errors) = response.errors {
                 let zeroth_error = errors[0].clone();
 
-                return Err(GaloyClientError::GraphQLApi {
+                return Err(GaloyClientError::GraphQLTopLevel {
                     message: zeroth_error.message,
                     path: zeroth_error.path.into(),
-                    location: zeroth_error.locations,
+                    locations: zeroth_error.locations,
                     extensions: zeroth_error.extensions,
                 });
             }
         }
 
         let response_data = response.data;
-        let result = response_data.ok_or_else(|| GaloyClientError::GraphQLApi {
+        let result = response_data.ok_or_else(|| GaloyClientError::GraphQLNested {
             message: "Empty `me` in response data".to_string(),
-            path: PathString(None),
-            location: None,
-            extensions: None,
+            path: None,
         })?;
 
         let wallet_id = WalletId::try_from(result)?;
@@ -195,20 +193,20 @@ impl GaloyClient {
         if let Some(errors) = response.errors {
             let zeroth_error = errors[0].clone();
 
-            return Err(GaloyClientError::GraphQLApi {
+            return Err(GaloyClientError::GraphQLTopLevel {
                 message: zeroth_error.message,
                 path: zeroth_error.path.into(),
-                location: zeroth_error.locations,
+                locations: zeroth_error.locations,
                 extensions: zeroth_error.extensions,
             });
         }
 
-        let result = response.data.ok_or_else(|| GaloyClientError::GraphQLApi {
-            message: "Empty `me` in response data".to_string(),
-            path: PathString(None),
-            location: None,
-            extensions: None,
-        })?;
+        let result = response
+            .data
+            .ok_or_else(|| GaloyClientError::GraphQLNested {
+                message: "Empty `me` in response data".to_string(),
+                path: None,
+            })?;
         GaloyTransactions::try_from(result)
     }
 
@@ -225,21 +223,19 @@ impl GaloyClient {
             if let Some(errors) = response.errors {
                 let zeroth_error = errors[0].clone();
 
-                return Err(GaloyClientError::GraphQLApi {
+                return Err(GaloyClientError::GraphQLTopLevel {
                     message: zeroth_error.message,
                     path: zeroth_error.path.into(),
-                    location: zeroth_error.locations,
+                    locations: zeroth_error.locations,
                     extensions: zeroth_error.extensions,
                 });
             }
         }
 
         let response_data = response.data;
-        let result = response_data.ok_or_else(|| GaloyClientError::GraphQLApi {
+        let result = response_data.ok_or_else(|| GaloyClientError::GraphQLNested {
             message: "Empty `me` in response data".to_string(),
-            path: PathString(None),
-            location: None,
-            extensions: None,
+            path: None,
         })?;
 
         WalletBalances::try_from(result)
@@ -262,32 +258,28 @@ impl GaloyClient {
             if let Some(errors) = response.errors {
                 let zeroth_error = errors[0].clone();
 
-                return Err(GaloyClientError::GraphQLApi {
+                return Err(GaloyClientError::GraphQLTopLevel {
                     message: zeroth_error.message,
                     path: zeroth_error.path.into(),
-                    location: zeroth_error.locations,
+                    locations: zeroth_error.locations,
                     extensions: zeroth_error.extensions,
                 });
             }
         }
 
         let response_data = response.data;
-        let result = response_data.ok_or_else(|| GaloyClientError::GraphQLApi {
+        let result = response_data.ok_or_else(|| GaloyClientError::GraphQLNested {
             message: "Empty `on chain address create` in response data".to_string(),
-            path: PathString(None),
-            location: None,
-            extensions: None,
+            path: None,
         })?;
 
         let onchain_address_create = StablesatsOnchainAddress::try_from(result)?;
         let address =
             onchain_address_create
                 .address
-                .ok_or_else(|| GaloyClientError::GraphQLApi {
+                .ok_or_else(|| GaloyClientError::GraphQLNested {
                     message: "Empty `address` in response data".to_string(),
-                    path: PathString(None),
-                    location: None,
-                    extensions: None,
+                    path: None,
                 })?;
 
         Ok(OnchainAddress { address })
@@ -320,40 +312,34 @@ impl GaloyClient {
             if let Some(errors) = response.errors {
                 let zeroth_error = errors[0].clone();
 
-                return Err(GaloyClientError::GraphQLApi {
+                return Err(GaloyClientError::GraphQLTopLevel {
                     message: zeroth_error.message,
                     path: zeroth_error.path.into(),
-                    location: zeroth_error.locations,
+                    locations: zeroth_error.locations,
                     extensions: zeroth_error.extensions,
                 });
             }
         }
 
         let response_data = response.data;
-        let result = response_data.ok_or_else(|| GaloyClientError::GraphQLApi {
+        let result = response_data.ok_or_else(|| GaloyClientError::GraphQLNested {
             message: "Empty `onChainPaymentSend` in response data".to_string(),
-            path: PathString(None),
-            location: None,
-            extensions: None,
+            path: None,
         })?;
 
         let onchain_payment_send = StablesatsPaymentSend::try_from(result)?;
         if !onchain_payment_send.errors.is_empty() {
             let zeroth_error = onchain_payment_send.errors[0].clone();
-            return Err(GaloyClientError::GraphQLApi {
+            return Err(GaloyClientError::GraphQLNested {
                 message: zeroth_error.message,
-                path: PathString(zeroth_error.path),
-                location: None,
-                extensions: None,
+                path: zeroth_error.path,
             });
         };
 
         let payment_status = onchain_payment_send.status;
-        let status = payment_status.ok_or_else(|| GaloyClientError::GraphQLApi {
+        let status = payment_status.ok_or_else(|| GaloyClientError::GraphQLNested {
             message: "Empty `status` in response data".to_string(),
-            path: PathString(None),
-            location: None,
-            extensions: None,
+            path: None,
         })?;
 
         Ok(status)
@@ -382,21 +368,19 @@ impl GaloyClient {
             if let Some(errors) = response.errors {
                 let zeroth_error = errors[0].clone();
 
-                return Err(GaloyClientError::GraphQLApi {
+                return Err(GaloyClientError::GraphQLTopLevel {
                     message: zeroth_error.message,
                     path: zeroth_error.path.into(),
-                    location: zeroth_error.locations,
+                    locations: zeroth_error.locations,
                     extensions: zeroth_error.extensions,
                 });
             }
         }
 
         let response_data = response.data;
-        let result = response_data.ok_or_else(|| GaloyClientError::GraphQLApi {
+        let result = response_data.ok_or_else(|| GaloyClientError::GraphQLNested {
             message: "Empty `onChainTxFee` in response data".to_string(),
-            path: PathString(None),
-            location: None,
-            extensions: None,
+            path: None,
         })?;
 
         let onchain_tx_fee = StablesatsTxFee::try_from(result)?;

--- a/galoy-client/src/client/queries.rs
+++ b/galoy-client/src/client/queries.rs
@@ -6,7 +6,7 @@ use graphql_client::GraphQLQuery;
 use rust_decimal::Decimal;
 use serde::Deserialize;
 
-use crate::{GaloyClientError, PathString};
+use crate::GaloyClientError;
 
 pub(super) type SafeInt = Decimal;
 
@@ -64,11 +64,9 @@ impl TryFrom<stablesats_user_login::ResponseData> for StablesatsAuthToken {
         if !errors.is_empty() {
             let error = errors[0].clone();
 
-            return Err(GaloyClientError::GraphQLApi {
+            return Err(GaloyClientError::GraphQLNested {
                 message: error.message,
-                path: PathString(error.path),
-                location: None,
-                extensions: None,
+                path: error.path,
             });
         }
         Ok(auth_token)

--- a/galoy-client/src/client/queries.rs
+++ b/galoy-client/src/client/queries.rs
@@ -62,7 +62,7 @@ impl TryFrom<stablesats_user_login::ResponseData> for StablesatsAuthToken {
         let user_login = response.user_login;
         let (auth_token, errors) = (user_login.auth_token, user_login.errors);
 
-        if errors.len() > 0 {
+        if !errors.is_empty() {
             let mut errors_list = Vec::new();
             for error in errors {
                 let err = InnerError::from(error);
@@ -157,3 +157,6 @@ impl TryFrom<stablesats_on_chain_payment::ResponseData> for StablesatsPaymentSen
         Ok(onchain_payment_send)
     }
 }
+
+pub type StablesatsPaymentSendError =
+    stablesats_on_chain_payment::StablesatsOnChainPaymentOnChainPaymentSendErrors;

--- a/galoy-client/src/error.rs
+++ b/galoy-client/src/error.rs
@@ -1,3 +1,9 @@
+use std::collections::HashMap;
+
+use graphql_client::{Location, PathFragment};
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::hash_map::RandomState;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -10,4 +16,18 @@ pub enum GaloyClientError {
     GraphQLApi(String),
     #[error("GaloyClientError - Authentication: {0}")]
     Authentication(String),
+}
+
+#[derive(Debug, Deserialize)]
+pub struct InnerError {
+    pub message: String,
+    pub path: Option<Vec<Option<String>>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TopLevelError {
+    pub message: String,
+    pub path: std::option::Option<Vec<PathFragment>>,
+    pub location: Option<Vec<Location>>,
+    pub extensions: Option<HashMap<String, Value, RandomState>>,
 }

--- a/galoy-client/src/error.rs
+++ b/galoy-client/src/error.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use graphql_client::Location;
-// use serde::Deserialize;
 use serde_json::Value;
 use std::collections::hash_map::RandomState;
 use thiserror::Error;
@@ -14,13 +13,22 @@ pub enum GaloyClientError {
     Reqwest(#[from] reqwest::Error),
     #[error("GaloyClientError - InvalidHeaderValue: {0}")]
     Header(#[from] reqwest::header::InvalidHeaderValue),
-    #[error("GaloyClientError - GrqphqlApi{{ msg: {message:?}, path: {path:?}, loc: {location:?}, ext: {extensions:?} }}")]
-    GraphQLApi {
+    #[error("GaloyClientError - GraphQLNested {{ message: {message:?}, path: {path:?} }}")]
+    GraphQLNested {
+        message: String,
+        path: Option<Vec<Option<String>>>,
+    },
+    #[error(
+        "GaloyClientError - GraphQLTopLevel {{ message: {message:?}, path: {path:?}, locations: {locations:?}, extensions: {extensions:?} }}"
+    )]
+    GraphQLTopLevel {
         message: String,
         path: PathString,
-        location: Option<Vec<Location>>,
+        locations: Option<Vec<Location>>,
         extensions: Option<HashMap<String, Value, RandomState>>,
     },
     #[error("GaloyClientError - Authentication: {0}")]
     Authentication(String),
+    #[error("GaloyClientError - Serde: {0}")]
+    Serde(#[from] serde_json::Error),
 }

--- a/galoy-client/src/error.rs
+++ b/galoy-client/src/error.rs
@@ -31,3 +31,16 @@ pub struct TopLevelError {
     pub location: Option<Vec<Location>>,
     pub extensions: Option<HashMap<String, Value, RandomState>>,
 }
+
+impl TopLevelError {
+    pub fn create(errors: Vec<graphql_client::Error>) -> Result<Self, GaloyClientError> {
+        let mut errors_list = Vec::new();
+
+        for error in errors {
+            let err = Self::from(error);
+            errors_list.push(err)
+        }
+
+        Err(GaloyClientError::GraphQLApi(format!("{:#?}", errors_list)))
+    }
+}

--- a/galoy-client/src/error.rs
+++ b/galoy-client/src/error.rs
@@ -1,10 +1,12 @@
 use std::collections::HashMap;
 
-use graphql_client::{Location, PathFragment};
-use serde::Deserialize;
+use graphql_client::Location;
+// use serde::Deserialize;
 use serde_json::Value;
 use std::collections::hash_map::RandomState;
 use thiserror::Error;
+
+use crate::PathString;
 
 #[derive(Error, Debug)]
 pub enum GaloyClientError {
@@ -12,35 +14,13 @@ pub enum GaloyClientError {
     Reqwest(#[from] reqwest::Error),
     #[error("GaloyClientError - InvalidHeaderValue: {0}")]
     Header(#[from] reqwest::header::InvalidHeaderValue),
-    #[error("GaloyClientError - GrqphqlApi: {0}")]
-    GraphQLApi(String),
+    #[error("GaloyClientError - GrqphqlApi{{ msg: {message:?}, path: {path:?}, loc: {location:?}, ext: {extensions:?} }}")]
+    GraphQLApi {
+        message: String,
+        path: PathString,
+        location: Option<Vec<Location>>,
+        extensions: Option<HashMap<String, Value, RandomState>>,
+    },
     #[error("GaloyClientError - Authentication: {0}")]
     Authentication(String),
-}
-
-#[derive(Debug, Deserialize)]
-pub struct InnerError {
-    pub message: String,
-    pub path: Option<Vec<Option<String>>>,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct TopLevelError {
-    pub message: String,
-    pub path: std::option::Option<Vec<PathFragment>>,
-    pub location: Option<Vec<Location>>,
-    pub extensions: Option<HashMap<String, Value, RandomState>>,
-}
-
-impl TopLevelError {
-    pub fn create(errors: Vec<graphql_client::Error>) -> Result<Self, GaloyClientError> {
-        let mut errors_list = Vec::new();
-
-        for error in errors {
-            let err = Self::from(error);
-            errors_list.push(err)
-        }
-
-        Err(GaloyClientError::GraphQLApi(format!("{:#?}", errors_list)))
-    }
 }


### PR DESCRIPTION
## What this PR does?
- Introduces `GrapgQLNested` and `GrapgQLTopLevel`  error variants from the Graphql API
- Propagates these errors to `GaloyClientError`

## Related Issue
- fixes #115 