### PR TITLE
feat: Kollider-integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,8 +1199,11 @@ name = "kollider-price"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "rust_decimal",
  "serde",
  "serde_json",
+ "stablesats-shared",
+ "thiserror",
  "tokio",
  "tokio-tungstenite",
 ]
@@ -2526,6 +2529,7 @@ dependencies = [
  "futures",
  "galoy-client",
  "hedging",
+ "kollider-price",
  "okex-client",
  "okex-price",
  "opentelemetry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,6 +1198,8 @@ dependencies = [
 name = "kollider-price"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "chrono",
  "futures",
  "rust_decimal",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1208,6 +1208,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-tungstenite",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,6 +1195,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kollider-price"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ members = [
   "okex-price",
   "okex-client",
   "galoy-client",
+  "kollider-price",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,9 +15,10 @@ galoy-client = { path = "../galoy-client" }
 okex-client = { path = "../okex-client" }
 hedging = { path = "../hedging" }
 okex-price = { path = "../okex-price" }
+kollider-price = { path = "../kollider-price" }
 
 anyhow = "1.0.66"
-clap = { version =  "4.0", features = ["derive", "env"] }
+clap = { version = "4.0", features = ["derive", "env"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_yaml = "0.9.14"
 tokio = "1.21.2"

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -165,7 +165,7 @@ async fn run_cmd(
         let pubsub = pubsub.clone();
         handles.push(tokio::spawn(async move {
             let _ = kollider_send.try_send(
-                kollider_price::run(pubsub)
+                kollider_price::run(kollider_price_feed.config, pubsub)
                     .await
                     .context("Kollider Price Feed error"),
             );

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -117,6 +117,7 @@ async fn run_cmd(
         galoy,
         okex,
         hedging,
+        kollider_price_feed,
     }: Config,
 ) -> anyhow::Result<()> {
     println!("Starting server process");
@@ -156,6 +157,21 @@ async fn run_cmd(
             );
         }));
     }
+
+    if kollider_price_feed.enabled {
+        println!("Starting Kollider price feed");
+
+        let kollider_send = send.clone();
+        let pubsub = pubsub.clone();
+        handles.push(tokio::spawn(async move {
+            let _ = kollider_send.try_send(
+                kollider_price::run(pubsub)
+                    .await
+                    .context("Kollider Price Feed error"),
+            );
+        }));
+    }
+
     if hedging.enabled {
         println!("Starting hedging process");
         let hedging_send = send.clone();

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -30,6 +30,8 @@ pub struct Config {
     pub okex: OkexClientConfig,
     #[serde(default)]
     pub hedging: HedgingConfigWrapper,
+    #[serde(default)]
+    pub kollider_price_feed: KolliderPriceFeedConfigWrapper,
 }
 
 pub struct EnvOverride {
@@ -102,6 +104,17 @@ impl Default for PriceFeedConfigWrapper {
             enabled: true,
             config: PriceFeedConfig::default(),
         }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KolliderPriceFeedConfigWrapper {
+    #[serde(default = "bool_true")]
+    pub enabled: bool,
+}
+impl Default for KolliderPriceFeedConfigWrapper {
+    fn default() -> Self {
+        Self { enabled: true }
     }
 }
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -111,10 +111,16 @@ impl Default for PriceFeedConfigWrapper {
 pub struct KolliderPriceFeedConfigWrapper {
     #[serde(default = "bool_true")]
     pub enabled: bool,
+
+    #[serde(default)]
+    pub config: KolliderPriceFeedConfig,
 }
 impl Default for KolliderPriceFeedConfigWrapper {
     fn default() -> Self {
-        Self { enabled: true }
+        Self {
+            enabled: true,
+            config: PriceFeedConfig::default,
+        }
     }
 }
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use kollider_price::config::KolliderPriceFeedConfig;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -119,7 +120,7 @@ impl Default for KolliderPriceFeedConfigWrapper {
     fn default() -> Self {
         Self {
             enabled: true,
-            config: PriceFeedConfig::default,
+            config: KolliderPriceFeedConfig::default(),
         }
     }
 }

--- a/kollider-price/Cargo.toml
+++ b/kollider-price/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "kollider-price"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+futures = "0.3.25"
+serde = { version = "1.0.147", features = ["derive"] }
+serde_json = "1.0.87"
+tokio = { version = "1.21.2", features = ["full"] }
+tokio-tungstenite = { version = "0.17.2", features = [
+    "rustls-tls-webpki-roots",
+] }

--- a/kollider-price/Cargo.toml
+++ b/kollider-price/Cargo.toml
@@ -14,6 +14,7 @@ tokio-tungstenite = { version = "0.17.2", features = [
 shared = { path = "../shared", package = "stablesats-shared" }
 thiserror = "1.0.37"
 rust_decimal = "1.26.1"
+url = { version = "2.3.1", features = ["serde"] }
 
 
 [dev-dependencies]

--- a/kollider-price/Cargo.toml
+++ b/kollider-price/Cargo.toml
@@ -11,3 +11,6 @@ tokio = { version = "1.21.2", features = ["full"] }
 tokio-tungstenite = { version = "0.17.2", features = [
     "rustls-tls-webpki-roots",
 ] }
+shared = { path = "../shared", package = "stablesats-shared" }
+thiserror = "1.0.37"
+rust_decimal = "1.26.1"

--- a/kollider-price/Cargo.toml
+++ b/kollider-price/Cargo.toml
@@ -14,3 +14,11 @@ tokio-tungstenite = { version = "0.17.2", features = [
 shared = { path = "../shared", package = "stablesats-shared" }
 thiserror = "1.0.37"
 rust_decimal = "1.26.1"
+
+
+[dev-dependencies]
+anyhow = "1.0.66"
+chrono = { version = "0.4", features = [
+    "clock",
+    "serde",
+], default-features = false }

--- a/kollider-price/src/convert.rs
+++ b/kollider-price/src/convert.rs
@@ -1,0 +1,23 @@
+use super::price_feed::error::KolliderPriceFeedError;
+use super::price_feed::KolliderPriceTicker;
+
+use shared::{
+    payload::{
+        ExchangeIdRaw, InstrumentIdRaw, KolliderBtcUsdSwapPricePayload, PriceMessagePayload,
+        PriceRatioRaw,
+    },
+    time::TimeStamp,
+};
+
+impl TryFrom<KolliderPriceTicker> for KolliderBtcUsdSwapPricePayload {
+    type Error = KolliderPriceFeedError;
+    fn try_from(value: KolliderPriceTicker) -> Result<Self, Self::Error> {
+        Ok(KolliderBtcUsdSwapPricePayload(PriceMessagePayload {
+            exchange: ExchangeIdRaw::from("Kollider"), // FIXME
+            instrument_id: InstrumentIdRaw::from(value.symbol),
+            timestamp: TimeStamp::now(), //FIXME
+            ask_price: PriceRatioRaw::from_one_btc_in_usd_price(value.best_ask),
+            bid_price: PriceRatioRaw::from_one_btc_in_usd_price(value.best_bid),
+        }))
+    }
+}

--- a/kollider-price/src/convert.rs
+++ b/kollider-price/src/convert.rs
@@ -14,8 +14,8 @@ impl TryFrom<KolliderPriceTicker> for KolliderBtcUsdSwapPricePayload {
     fn try_from(value: KolliderPriceTicker) -> Result<Self, Self::Error> {
         Ok(KolliderBtcUsdSwapPricePayload(PriceMessagePayload {
             exchange: ExchangeIdRaw::from("Kollider"), // FIXME
-            instrument_id: InstrumentIdRaw::from(value.symbol),
-            timestamp: TimeStamp::now(), //FIXME
+            instrument_id: InstrumentIdRaw::from("BTC-USD-SWAP"), // FIXME "BTC-USD-SWAP"
+            timestamp: TimeStamp::now(),               //FIXME
             ask_price: PriceRatioRaw::from_one_btc_in_usd_price(value.best_ask),
             bid_price: PriceRatioRaw::from_one_btc_in_usd_price(value.best_bid),
         }))

--- a/kollider-price/src/lib.rs
+++ b/kollider-price/src/lib.rs
@@ -32,17 +32,17 @@ pub async fn run(
 mod tests {
     use crate::{config::KolliderPriceFeedConfig, price_feed::subscribe_price_feed};
     use futures::StreamExt;
+    use url::Url;
 
     #[tokio::test]
-    async fn test_get_price() {
-        let config = KolliderPriceFeedConfig::default();
-        let mut stream = subscribe_price_feed(config).await.unwrap();
+    async fn test_get_price() -> anyhow::Result<()> {
+        let config = KolliderPriceFeedConfig {
+            url: Url::parse("wss://testnet.kollider.xyz/v1/ws/")?,
+        };
+        let mut stream = subscribe_price_feed(config).await?;
         if let Some(tick) = stream.next().await {
             println!("first tick connect: {:?}", tick);
         }
-
-        if let Some(tick) = stream.next().await {
-            println!("second tick price_feed: {:?}", tick);
-        }
+        Ok(())
     }
 }

--- a/kollider-price/src/lib.rs
+++ b/kollider-price/src/lib.rs
@@ -1,22 +1,24 @@
 use std::io::Error;
 
 use futures::StreamExt;
+mod price_feed;
+use price_feed::config::KolliderPriceFeedConfig;
 pub use price_feed::*;
 use shared::{
     payload::KolliderBtcUsdSwapPricePayload,
     pubsub::{PubSubConfig, Publisher},
 };
-mod price_feed;
 
 mod convert;
 
-pub async fn run(pubsub_cfg: PubSubConfig) -> Result<(), Error> {
+pub async fn run(
+    price_feed_config: KolliderPriceFeedConfig,
+    pubsub_cfg: PubSubConfig,
+) -> Result<(), Error> {
     let publisher = Publisher::new(pubsub_cfg).await.unwrap(); //FIXME
 
-    let mut stream = subscribe_price_feed().await.unwrap(); // FIXME
+    let mut stream = subscribe_price_feed(price_feed_config).await.unwrap(); // FIXME
     while let Some(tick) = stream.next().await {
-        //let _ = okex_price_tick_received(&publisher, tick).await;
-
         println!("publish payload {:?}", tick);
         if let Ok(payload) = KolliderBtcUsdSwapPricePayload::try_from(tick) {
             publisher.throttle_publish(payload).await.unwrap();
@@ -28,12 +30,13 @@ pub async fn run(pubsub_cfg: PubSubConfig) -> Result<(), Error> {
 
 #[cfg(test)]
 mod tests {
-    use crate::price_feed::subscribe_price_feed;
+    use crate::{config::KolliderPriceFeedConfig, price_feed::subscribe_price_feed};
     use futures::StreamExt;
 
     #[tokio::test]
     async fn test_get_price() {
-        let mut stream = subscribe_price_feed().await.unwrap();
+        let config = KolliderPriceFeedConfig::default();
+        let mut stream = subscribe_price_feed(config).await.unwrap();
         while let Some(tick) = stream.next().await {
             println!("result: {:?}", tick);
         }

--- a/kollider-price/src/lib.rs
+++ b/kollider-price/src/lib.rs
@@ -1,0 +1,11 @@
+mod price_feed;
+
+#[cfg(test)]
+mod tests {
+    use crate::price_feed::poll_price;
+
+    #[tokio::test]
+    async fn test_get_price() {
+        poll_price().await;
+    }
+}

--- a/kollider-price/src/lib.rs
+++ b/kollider-price/src/lib.rs
@@ -1,11 +1,46 @@
+use std::io::Error;
+
+use futures::StreamExt;
+pub use price_feed::*;
+use shared::{
+    payload::KolliderBtcUsdSwapPricePayload,
+    pubsub::{PubSubConfig, Publisher},
+};
 mod price_feed;
+
+mod convert;
+
+pub async fn run(pubsub_cfg: PubSubConfig) -> Result<(), Error> {
+    let publisher = Publisher::new(pubsub_cfg).await.unwrap(); //FIXME
+
+    let mut stream = subscribe_price_feed().await.unwrap(); // FIXME
+    while let Some(tick) = stream.next().await {
+        //let _ = okex_price_tick_received(&publisher, tick).await;
+
+        println!("publish payload {:?}", tick);
+        if let Ok(payload) = KolliderBtcUsdSwapPricePayload::try_from(tick) {
+            publisher.throttle_publish(payload).await.unwrap();
+        }
+    }
+
+    Ok(())
+}
 
 #[cfg(test)]
 mod tests {
-    use crate::price_feed::poll_price;
+    use crate::price_feed::subscribe_price_feed;
+    use futures::StreamExt;
 
     #[tokio::test]
     async fn test_get_price() {
-        poll_price().await;
+        let mut stream = subscribe_price_feed().await.unwrap();
+        while let Some(tick) = stream.next().await {
+            println!("result: {:?}", tick);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_it() {
+        println!("hhmm");
     }
 }

--- a/kollider-price/src/price_feed/config.rs
+++ b/kollider-price/src/price_feed/config.rs
@@ -1,0 +1,15 @@
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct KolliderPriceFeedConfig {
+    pub url: Url,
+}
+
+impl Default for KolliderPriceFeedConfig {
+    fn default() -> Self {
+        Self {
+            url: Url::parse("wss://testnet.kollider.xyz/v1/ws/").unwrap(),
+        }
+    }
+}

--- a/kollider-price/src/price_feed/config.rs
+++ b/kollider-price/src/price_feed/config.rs
@@ -9,7 +9,7 @@ pub struct KolliderPriceFeedConfig {
 impl Default for KolliderPriceFeedConfig {
     fn default() -> Self {
         Self {
-            url: Url::parse("wss://testnet.kollider.xyz/v1/ws/").unwrap(),
+            url: Url::parse("wss://kollider.xyz/v1/ws/").unwrap(),
         }
     }
 }

--- a/kollider-price/src/price_feed/error.rs
+++ b/kollider-price/src/price_feed/error.rs
@@ -1,4 +1,17 @@
+use serde_json::Error as SerdeError;
+use shared::pubsub::PublisherError;
 use thiserror::Error;
 
+use tokio_tungstenite::tungstenite::error::Error as TungsteniteError;
+
 #[derive(Error, Debug)]
-pub enum KolliderPriceFeedError {}
+pub enum KolliderPriceFeedError {
+    #[error("PriceFeedError - SerdeError: {0}")]
+    SerializationError(#[from] SerdeError),
+
+    #[error("PriceFeedError - PublisherError: {0}")]
+    PublisherError(#[from] PublisherError),
+
+    #[error("PriceFeedError - TungsteniteError: {0}")]
+    TungsteniteError(#[from] TungsteniteError),
+}

--- a/kollider-price/src/price_feed/error.rs
+++ b/kollider-price/src/price_feed/error.rs
@@ -1,0 +1,4 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum KolliderPriceFeedError {}

--- a/kollider-price/src/price_feed/mod.rs
+++ b/kollider-price/src/price_feed/mod.rs
@@ -6,14 +6,17 @@ mod tick;
 pub use tick::*;
 
 pub mod error;
+
+pub mod config;
+
+use config::KolliderPriceFeedConfig;
 use error::KolliderPriceFeedError;
 
 pub async fn subscribe_price_feed(
+    config: KolliderPriceFeedConfig,
 ) -> Result<std::pin::Pin<Box<dyn Stream<Item = KolliderPriceTicker> + Send>>, KolliderPriceFeedError>
 {
-    let (ws_stream, _) = connect_async("wss://testnet.kollider.xyz/v1/ws/")
-        .await
-        .unwrap(); // FIXME
+    let (ws_stream, _) = connect_async(config.url).await.unwrap(); // FIXME
 
     let (mut sender, receiver) = ws_stream.split();
 

--- a/kollider-price/src/price_feed/mod.rs
+++ b/kollider-price/src/price_feed/mod.rs
@@ -1,22 +1,19 @@
 use futures::{SinkExt, Stream, StreamExt};
 
-use tokio_tungstenite::{connect_async, tungstenite::Message};
-
-mod tick;
-pub use tick::*;
-
-pub mod error;
-
-pub mod config;
-
 use config::KolliderPriceFeedConfig;
 use error::KolliderPriceFeedError;
+pub use tick::*;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+pub mod config;
+pub mod error;
+mod tick;
 
 pub async fn subscribe_price_feed(
     config: KolliderPriceFeedConfig,
 ) -> Result<std::pin::Pin<Box<dyn Stream<Item = KolliderPriceTicker> + Send>>, KolliderPriceFeedError>
 {
-    let (ws_stream, _) = connect_async(config.url).await.unwrap(); // FIXME
+    let (ws_stream, _) = connect_async(config.url).await?;
 
     let (mut sender, receiver) = ws_stream.split();
 

--- a/kollider-price/src/price_feed/mod.rs
+++ b/kollider-price/src/price_feed/mod.rs
@@ -1,0 +1,47 @@
+use futures::{SinkExt, StreamExt};
+
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+mod tick;
+pub use tick::*;
+
+pub async fn poll_price() {
+    let (ws_stream, _) = connect_async("wss://testnet.kollider.xyz/v1/ws/")
+        .await
+        .unwrap();
+
+    let (mut sender, receiver) = ws_stream.split();
+
+    let subscribe_args = serde_json::json!({
+        "type": "subscribe",
+        "symbols": ["BTCUSD.PERP"],
+        "channels": ["ticker"]
+    })
+    .to_string();
+    let item = Message::Text(subscribe_args);
+
+    sender.send(item).await.unwrap();
+
+    receiver
+        .for_each(|message| async {
+            let msg = message.unwrap();
+
+            if let Message::Text(txt) = msg {
+                println!("tick raw: {}", txt);
+
+                // connected msg:
+                // {"data":"Subscribed to channel \"ticker:BTCUSD.PERP\" successfully.","type":"success"}
+
+                // ticker msg:
+                // {"data":{"best_ask":"20738.0","best_bid":"20733.0","last_price":"20738.5","last_quantity":14,"last_side":"Bid","mid":"20735.5","symbol":"BTCUSD.PERP"},"seq":1,"type":"ticker"}
+
+                if !txt.contains("success") {
+                    let ticker: KolliderPriceTickerRoot = serde_json::from_str(&txt).unwrap();
+                    println!("tick: {:?}", ticker.data);
+                } else {
+                    println!("connect: {:?}", txt);
+                }
+            }
+        })
+        .await;
+}

--- a/kollider-price/src/price_feed/tick.rs
+++ b/kollider-price/src/price_feed/tick.rs
@@ -1,0 +1,19 @@
+use serde::Deserialize;
+
+#[derive(Default, Debug, Clone, Deserialize)]
+pub struct KolliderPriceTickerRoot {
+    pub data: KolliderPriceTicker,
+    #[serde(rename = "type")]
+    pub type_str: String,
+}
+
+#[derive(Default, Debug, Clone, Deserialize)]
+pub struct KolliderPriceTicker {
+    pub best_ask: String,
+    pub best_bid: String,
+    pub last_price: String,
+    pub last_quantity: i64,
+    pub last_side: String,
+    pub mid: String,
+    pub symbol: String,
+}

--- a/kollider-price/src/price_feed/tick.rs
+++ b/kollider-price/src/price_feed/tick.rs
@@ -1,3 +1,4 @@
+use rust_decimal::Decimal;
 use serde::Deserialize;
 
 #[derive(Default, Debug, Clone, Deserialize)]
@@ -9,9 +10,9 @@ pub struct KolliderPriceTickerRoot {
 
 #[derive(Default, Debug, Clone, Deserialize)]
 pub struct KolliderPriceTicker {
-    pub best_ask: String,
-    pub best_bid: String,
-    pub last_price: String,
+    pub best_ask: Decimal,
+    pub best_bid: Decimal,
+    pub last_price: Decimal,
     pub last_quantity: i64,
     pub last_side: String,
     pub mid: String,

--- a/kollider-price/tests/fixtures/price_feed.json
+++ b/kollider-price/tests/fixtures/price_feed.json
@@ -1,0 +1,21 @@
+{
+  "payloads": [
+    {
+      "exchange": "Kollider",
+      "instrumentId": "BTC-USD-SWAP",
+      "timestamp": 1,
+      "bidPrice": {
+        "numeratorUnit": "USD_CENT",
+        "denominatorUnit": "BTC_SAT",
+        "offset": 12,
+        "base": "8888880000"
+      },
+      "askPrice": {
+        "numeratorUnit": "USD_CENT",
+        "denominatorUnit": "BTC_SAT",
+        "offset": 12,
+        "base": "9999990000"
+      }
+    }
+  ]
+}

--- a/kollider-price/tests/price_feed.rs
+++ b/kollider-price/tests/price_feed.rs
@@ -1,0 +1,40 @@
+use futures::StreamExt;
+use std::fs;
+
+use shared::{payload::*, pubsub::*};
+
+#[derive(serde::Deserialize)]
+struct Fixture {
+    payloads: Vec<PriceMessagePayload>,
+}
+
+fn load_fixture() -> anyhow::Result<Fixture> {
+    let contents =
+        fs::read_to_string("./tests/fixtures/price_feed.json").expect("Couldn't load fixtures");
+    Ok(serde_json::from_str(&contents)?)
+}
+
+#[tokio::test]
+async fn publishes_to_redis() -> anyhow::Result<()> {
+    let redis_host = std::env::var("REDIS_HOST").unwrap_or("localhost".to_string());
+    let pubsub_config = PubSubConfig {
+        host: Some(redis_host),
+        ..PubSubConfig::default()
+    };
+    let subscriber = Subscriber::new(pubsub_config.clone()).await?;
+
+    let _ = tokio::spawn(async move {
+        let _ = kollider_price::run(pubsub_config).await;
+    });
+
+    let mut stream = subscriber
+        .subscribe::<KolliderBtcUsdSwapPricePayload>()
+        .await?;
+    let received = stream.next().await.expect("expected price tick");
+
+    let payload = &load_fixture()?.payloads[0];
+    assert_eq!(received.payload.exchange, payload.exchange);
+    assert_eq!(received.payload.instrument_id, payload.instrument_id);
+
+    Ok(())
+}

--- a/kollider-price/tests/price_feed.rs
+++ b/kollider-price/tests/price_feed.rs
@@ -1,4 +1,5 @@
 use futures::StreamExt;
+use kollider_price::config::KolliderPriceFeedConfig;
 use std::fs;
 
 use shared::{payload::*, pubsub::*};
@@ -24,7 +25,8 @@ async fn publishes_to_redis() -> anyhow::Result<()> {
     let subscriber = Subscriber::new(pubsub_config.clone()).await?;
 
     let _ = tokio::spawn(async move {
-        let _ = kollider_price::run(pubsub_config).await;
+        let config = KolliderPriceFeedConfig::default();
+        let _ = kollider_price::run(config, pubsub_config).await;
     });
 
     let mut stream = subscriber

--- a/kollider-price/tests/price_feed.rs
+++ b/kollider-price/tests/price_feed.rs
@@ -1,6 +1,7 @@
 use futures::StreamExt;
 use kollider_price::config::KolliderPriceFeedConfig;
 use std::fs;
+use url::Url;
 
 use shared::{payload::*, pubsub::*};
 
@@ -25,7 +26,9 @@ async fn publishes_to_redis() -> anyhow::Result<()> {
     let subscriber = Subscriber::new(pubsub_config.clone()).await?;
 
     let _ = tokio::spawn(async move {
-        let config = KolliderPriceFeedConfig::default();
+        let config = KolliderPriceFeedConfig {
+            url: Url::parse("wss://testnet.kollider.xyz/v1/ws/").unwrap(),
+        };
         let _ = kollider_price::run(config, pubsub_config).await;
     });
 

--- a/shared/src/payload/mod.rs
+++ b/shared/src/payload/mod.rs
@@ -37,6 +37,23 @@ impl std::ops::Deref for OkexBtcUsdSwapPricePayload {
 crate::payload! { OkexBtcUsdSwapPricePayload, "price.okex.btc-usd-swap" }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct KolliderBtcUsdSwapPricePayload(pub PriceMessagePayload);
+impl From<KolliderBtcUsdSwapPricePayload> for PriceMessagePayload {
+    fn from(payload: KolliderBtcUsdSwapPricePayload) -> Self {
+        payload.0
+    }
+}
+impl std::ops::Deref for KolliderBtcUsdSwapPricePayload {
+    type Target = PriceMessagePayload;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+crate::payload! { KolliderBtcUsdSwapPricePayload, "price.kollider.btc-usd-swap" }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SynthUsdLiabilityPayload {
     pub liability: SyntheticCentLiability,
 }

--- a/stablesats.yml
+++ b/stablesats.yml
@@ -38,6 +38,11 @@
   # config:
   #   url: "wss://ws.okx.com:8443/ws/v5/public"
 
+  # kollider_price_feed:
+  # enabled: true
+  # config:
+  #   url: "wss://testnet.kollider.xyz/v1/ws/"
+
 # tracing:
 #   host: "localhost"
 #   port: 6831


### PR DESCRIPTION
This is the first step of adding support for the Kollider-exchange to stablesats: 

Adds a new crate that receives price-ticks from the Kollider-API and pushes them on the Redis pubsub.