### PR TITLE
fix: use 'delayed' fee for get_cents_from_sats_for_future_sell

### DIFF
--- a/price-server/src/app/mod.rs
+++ b/price-server/src/app/mod.rs
@@ -125,7 +125,7 @@ impl PriceApp {
             .await?
             .buy_usd()
             .sats_from_cents(cents);
-        Ok(self.fee_calculator.increase_by_immediate_fee(sats))
+        Ok(self.fee_calculator.increase_by_immediate_fee(sats).ceil())
     }
 
     #[instrument(skip_all, fields(correlation_id, amount = %cents.amount()), ret, err)]

--- a/price-server/src/app/mod.rs
+++ b/price-server/src/app/mod.rs
@@ -111,7 +111,7 @@ impl PriceApp {
             .await?
             .sell_usd()
             .cents_from_sats(sats);
-        Ok(self.fee_calculator.increase_by_immediate_fee(cents).ceil())
+        Ok(self.fee_calculator.increase_by_delayed_fee(cents).ceil())
     }
 
     #[instrument(skip_all, fields(correlation_id, amount = %cents.amount()), ret, err)]

--- a/price-server/tests/price_app.rs
+++ b/price-server/tests/price_app.rs
@@ -105,7 +105,7 @@ async fn price_app() -> anyhow::Result<()> {
     let future_buy = app
         .get_cents_from_sats_for_future_sell(Sats::from_major(100_000_000))
         .await?;
-    assert_eq!(future_buy, UsdCents::from_major(1011000));
+    assert_eq!(future_buy, UsdCents::from_major(1101000));
     let future_buy = app
         .get_cents_from_sats_for_future_sell(Sats::from_major(1))
         .await?;


### PR DESCRIPTION
## Description

Fixes a discrepancy first discovered when doing tests for `galoy` application code https://github.com/GaloyMoney/galoy/pull/1754#discussion_r991368855