### PR TITLE
Make price-server configurable to use Kollider instead of Okex

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -138,9 +138,15 @@ async fn run_cmd(
         checkers.insert("price", snd);
         handles.push(tokio::spawn(async move {
             let _ = price_send.try_send(
-                price_server::run(recv, price_server.server, price_server.fees, pubsub)
-                    .await
-                    .context("Price Server error"),
+                price_server::run(
+                    recv,
+                    price_server.server,
+                    price_server.fees,
+                    pubsub,
+                    price_server.app,
+                )
+                .await
+                .context("Price Server error"),
             );
         }));
     }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -7,7 +7,7 @@ use galoy_client::GaloyClientConfig;
 use hedging::HedgingAppConfig;
 use okex_client::OkexClientConfig;
 use okex_price::PriceFeedConfig;
-use price_server::{FeeCalculatorConfig, PriceServerConfig};
+use price_server::{app::PriceServerAppConfig, FeeCalculatorConfig, PriceServerConfig};
 use shared::pubsub::PubSubConfig;
 use user_trades::UserTradesConfig;
 
@@ -81,6 +81,8 @@ pub struct PriceServerWrapper {
     pub server: PriceServerConfig,
     #[serde(default)]
     pub fees: FeeCalculatorConfig,
+    #[serde(default)]
+    pub app: PriceServerAppConfig,
 }
 impl Default for PriceServerWrapper {
     fn default() -> Self {
@@ -88,6 +90,7 @@ impl Default for PriceServerWrapper {
             enabled: true,
             server: PriceServerConfig::default(),
             fees: FeeCalculatorConfig::default(),
+            app: PriceServerAppConfig::default(),
         }
     }
 }

--- a/price-server/src/app/config.rs
+++ b/price-server/src/app/config.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PriceServerAppConfig {
+    #[serde(default = "default_use_okex")]
+    pub use_okex: bool,
+}
+
+fn default_use_okex() -> bool {
+    true
+}
+
+impl Default for PriceServerAppConfig {
+    fn default() -> Self {
+        Self {
+            use_okex: default_use_okex(),
+        }
+    }
+}

--- a/price-server/src/exchange_price_cache.rs
+++ b/price-server/src/exchange_price_cache.rs
@@ -34,8 +34,21 @@ impl ExchangePriceCache {
         }
     }
 
-    pub async fn apply_update(&self, message: pubsub::Envelope<OkexBtcUsdSwapPricePayload>) {
-        self.inner.write().await.update_price(message);
+    pub async fn apply_update_okex(&self, message: pubsub::Envelope<OkexBtcUsdSwapPricePayload>) {
+        self.inner
+            .write()
+            .await
+            .update_price(message.payload.0, message.meta.correlation_id);
+    }
+
+    pub async fn apply_update_kollider(
+        &self,
+        message: pubsub::Envelope<KolliderBtcUsdSwapPricePayload>,
+    ) {
+        self.inner
+            .write()
+            .await
+            .update_price(message.payload.0, message.meta.correlation_id);
     }
 
     pub async fn latest_tick(&self) -> Result<BtcSatTick, ExchangePriceCacheError> {
@@ -86,8 +99,7 @@ impl ExchangePriceCacheInner {
         }
     }
 
-    fn update_price(&mut self, message: pubsub::Envelope<OkexBtcUsdSwapPricePayload>) {
-        let payload = message.payload.0;
+    fn update_price(&mut self, payload: PriceMessagePayload, id: CorrelationId) {
         if let Some(ref tick) = self.tick {
             if tick.timestamp > payload.timestamp {
                 return;
@@ -99,7 +111,7 @@ impl ExchangePriceCacheInner {
         ) {
             self.tick = Some(BtcSatTick {
                 timestamp: payload.timestamp,
-                correlation_id: message.meta.correlation_id,
+                correlation_id: id,
                 span_context: Span::current().context().span().span_context().clone(),
                 ask_price_of_one_sat,
                 bid_price_of_one_sat,

--- a/price-server/src/lib.rs
+++ b/price-server/src/lib.rs
@@ -9,7 +9,7 @@ mod server;
 
 use shared::{health::HealthCheckTrigger, pubsub::PubSubConfig};
 
-use app::PriceApp;
+use app::{PriceApp, PriceServerAppConfig};
 pub use exchange_price_cache::ExchangePriceCacheError;
 pub use fee_calculator::FeeCalculatorConfig;
 pub use server::*;
@@ -19,8 +19,9 @@ pub async fn run(
     server_config: PriceServerConfig,
     fee_calc_cfg: FeeCalculatorConfig,
     pubsub_cfg: PubSubConfig,
+    app_cfg: PriceServerAppConfig,
 ) -> Result<(), PriceServerError> {
-    let app = PriceApp::run(health_check_trigger, fee_calc_cfg, pubsub_cfg).await?;
+    let app = PriceApp::run(health_check_trigger, fee_calc_cfg, pubsub_cfg, app_cfg).await?;
 
     server::start(server_config, app).await?;
 

--- a/price-server/tests/price_app.rs
+++ b/price-server/tests/price_app.rs
@@ -36,6 +36,7 @@ async fn price_app() -> anyhow::Result<()> {
             delayed_fee_rate: dec!(0.1),
         },
         config,
+        PriceServerAppConfig::default(),
     )
     .await?;
 

--- a/stablesats.yml
+++ b/stablesats.yml
@@ -26,6 +26,8 @@
 
 # price_server:
   # enabled: true
+  # app:
+  #   use_okex: true
   # server:
   #   listen_port: 3325
   # fees:


### PR DESCRIPTION
* Adds a config app: use_okex to the stablesats.yml to configure which exchange to use for receiving prices
* If no config is provided the default Okex is used