### PR TITLE
refactor: configure stale_after & last_msg_delay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1974,6 +1974,7 @@ dependencies = [
  "rusty-money",
  "serde",
  "serde_json",
+ "serde_with",
  "stablesats-shared",
  "thiserror",
  "tokio",
@@ -2493,18 +2494,18 @@ checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e326c9ec8042f1b5da33252c8a37e9ffbd2c9bef0155215b6e6c80c790e05f91"
+checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a3df25b0713732468deadad63ab9da1f1fd75a48a15024b50363f128db627e"
+checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -138,9 +138,15 @@ async fn run_cmd(
         checkers.insert("price", snd);
         handles.push(tokio::spawn(async move {
             let _ = price_send.try_send(
-                price_server::run(recv, price_server.server, price_server.fees, pubsub)
-                    .await
-                    .context("Price Server error"),
+                price_server::run(
+                    recv,
+                    price_server.server,
+                    price_server.fees,
+                    pubsub,
+                    price_server.price_cache,
+                )
+                .await
+                .context("Price Server error"),
             );
         }));
     }

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -140,6 +140,7 @@ async fn run_cmd(
             let _ = price_send.try_send(
                 price_server::run(
                     recv,
+                    price_server.health,
                     price_server.server,
                     price_server.fees,
                     pubsub,

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -7,7 +7,9 @@ use galoy_client::GaloyClientConfig;
 use hedging::HedgingAppConfig;
 use okex_client::OkexClientConfig;
 use okex_price::PriceFeedConfig;
-use price_server::{ExchangePriceCacheConfig, FeeCalculatorConfig, PriceServerConfig};
+use price_server::{
+    ExchangePriceCacheConfig, FeeCalculatorConfig, PriceServerConfig, PriceServerHealthCheckConfig,
+};
 use shared::pubsub::PubSubConfig;
 use user_trades::UserTradesConfig;
 
@@ -78,6 +80,8 @@ pub struct PriceServerWrapper {
     #[serde(default = "bool_true")]
     pub enabled: bool,
     #[serde(default)]
+    pub health: PriceServerHealthCheckConfig,
+    #[serde(default)]
     pub server: PriceServerConfig,
     #[serde(default)]
     pub fees: FeeCalculatorConfig,
@@ -89,6 +93,7 @@ impl Default for PriceServerWrapper {
         Self {
             enabled: true,
             server: PriceServerConfig::default(),
+            health: PriceServerHealthCheckConfig::default(),
             fees: FeeCalculatorConfig::default(),
             price_cache: ExchangePriceCacheConfig::default(),
         }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -7,7 +7,7 @@ use galoy_client::GaloyClientConfig;
 use hedging::HedgingAppConfig;
 use okex_client::OkexClientConfig;
 use okex_price::PriceFeedConfig;
-use price_server::{FeeCalculatorConfig, PriceServerConfig};
+use price_server::{ExchangePriceCacheConfig, FeeCalculatorConfig, PriceServerConfig};
 use shared::pubsub::PubSubConfig;
 use user_trades::UserTradesConfig;
 
@@ -81,6 +81,8 @@ pub struct PriceServerWrapper {
     pub server: PriceServerConfig,
     #[serde(default)]
     pub fees: FeeCalculatorConfig,
+    #[serde(default)]
+    pub price_cache: ExchangePriceCacheConfig,
 }
 impl Default for PriceServerWrapper {
     fn default() -> Self {
@@ -88,6 +90,7 @@ impl Default for PriceServerWrapper {
             enabled: true,
             server: PriceServerConfig::default(),
             fees: FeeCalculatorConfig::default(),
+            price_cache: ExchangePriceCacheConfig::default(),
         }
     }
 }

--- a/hedging/src/app/config.rs
+++ b/hedging/src/app/config.rs
@@ -11,6 +11,12 @@ pub struct HedgingAppConfig {
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
     #[serde(default = "default_okex_poll_frequency")]
     pub okex_poll_frequency: Duration,
+    #[serde_as(as = "serde_with::DurationSeconds<i64>")]
+    #[serde(default = "default_unhealthy_msg_interval")]
+    pub unhealthy_msg_interval_liability: chrono::Duration,
+    #[serde_as(as = "serde_with::DurationSeconds<i64>")]
+    #[serde(default = "default_unhealthy_msg_interval")]
+    pub unhealthy_msg_interval_position: chrono::Duration,
 }
 
 impl Default for HedgingAppConfig {
@@ -19,6 +25,8 @@ impl Default for HedgingAppConfig {
             pg_con: "".to_string(),
             migrate_on_start: true,
             okex_poll_frequency: default_okex_poll_frequency(),
+            unhealthy_msg_interval_liability: default_unhealthy_msg_interval(),
+            unhealthy_msg_interval_position: default_unhealthy_msg_interval(),
         }
     }
 }
@@ -29,4 +37,9 @@ fn bool_true() -> bool {
 
 fn default_okex_poll_frequency() -> Duration {
     Duration::from_secs(10)
+}
+
+fn default_unhealthy_msg_interval() -> chrono::Duration {
+    chrono::Duration::from_std(Duration::from_secs(20))
+        .expect("bad default unhealthy_after_msg_delay")
 }

--- a/hedging/src/job/mod.rs
+++ b/hedging/src/job/mod.rs
@@ -72,6 +72,7 @@ pub async fn spawn_adjust_hedge<'a>(
     correlation_id: CorrelationId,
 ) -> Result<(), HedgingError> {
     match JobBuilder::new_with_id(Uuid::from(correlation_id), "adjust_hedge")
+        .set_ordered(true)
         .set_json(&AdjustHedgeData {
             tracing_data: shared::tracing::extract_tracing_data(),
             correlation_id,

--- a/hedging/tests/hedging.rs
+++ b/hedging/tests/hedging.rs
@@ -104,8 +104,8 @@ async fn hedging() -> anyhow::Result<()> {
             recv,
             HedgingAppConfig {
                 pg_con: pg_con.clone(),
-                migrate_on_start: true,
                 okex_poll_frequency: std::time::Duration::from_secs(2),
+                ..Default::default()
             },
             okex_client_config(),
             pubsub_config.clone(),
@@ -118,8 +118,8 @@ async fn hedging() -> anyhow::Result<()> {
                 recv,
                 HedgingAppConfig {
                     pg_con,
-                    migrate_on_start: true,
                     okex_poll_frequency: std::time::Duration::from_secs(2),
+                    ..Default::default()
                 },
                 okex_client_config(),
                 pubsub_config,

--- a/price-server/Cargo.toml
+++ b/price-server/Cargo.toml
@@ -14,20 +14,24 @@ fail-on-warnings = []
 [dependencies]
 shared = { path = "../shared", package = "stablesats-shared" }
 
-chrono = { version = "0.4", features = ["clock", "serde"], default-features = false }
+chrono = { version = "0.4", features = [
+    "clock",
+    "serde",
+], default-features = false }
 prost = "0.11"
 tonic = "0.8"
 axum-core = "0.3.0"
 tokio = "1.23.0"
 futures = "0.3.25"
 thiserror = "1.0.38"
-serde = "1.0.150"
+serde = { version = "1.0.151", features = ["derive"] }
 rust_decimal = "1.25.0"
 tracing = "0.1.37"
 opentelemetry = { version = "0.18.0", features = ["trace"] }
 tracing-opentelemetry = "0.18.0"
 rust_decimal_macros = "1.26.1"
 rusty-money = "0.4.1"
+serde_with = "2.1.0"
 
 [build-dependencies]
 protobuf-src = { version = "1.1.0" }

--- a/price-server/Cargo.toml
+++ b/price-server/Cargo.toml
@@ -31,7 +31,7 @@ opentelemetry = { version = "0.18.0", features = ["trace"] }
 tracing-opentelemetry = "0.18.0"
 rust_decimal_macros = "1.26.1"
 rusty-money = "0.4.1"
-serde_with = "2.1.0"
+serde_with = { version = "2.1.0", features = ["chrono_0_4"] }
 
 [build-dependencies]
 protobuf-src = { version = "1.1.0" }

--- a/price-server/src/app/config.rs
+++ b/price-server/src/app/config.rs
@@ -1,0 +1,23 @@
+use chrono::Duration;
+use serde::{Deserialize, Serialize};
+
+#[serde_with::serde_as]
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct PriceServerHealthCheckConfig {
+    #[serde_as(as = "serde_with::DurationSeconds<i64>")]
+    #[serde(default = "default_unhealthy_msg_interval_price")]
+    pub unhealthy_msg_interval_price: Duration,
+}
+
+impl Default for PriceServerHealthCheckConfig {
+    fn default() -> Self {
+        Self {
+            unhealthy_msg_interval_price: default_unhealthy_msg_interval_price(),
+        }
+    }
+}
+
+fn default_unhealthy_msg_interval_price() -> Duration {
+    Duration::from_std(std::time::Duration::from_secs(20))
+        .expect("bad default unhealthy_after_msg_delay")
+}

--- a/price-server/src/app/error.rs
+++ b/price-server/src/app/error.rs
@@ -12,4 +12,6 @@ pub enum PriceAppError {
     SubscriberError(#[from] SubscriberError),
     #[error("PriceAppError - ExchangePriceCacheError: {0}")]
     ExchangePriceCacheError(#[from] ExchangePriceCacheError),
+    #[error("PriceAppError - StdDurationConversionError: {0}")]
+    StdDurationConversionError(#[from] chrono::OutOfRangeError),
 }

--- a/price-server/src/app/mod.rs
+++ b/price-server/src/app/mod.rs
@@ -1,3 +1,4 @@
+mod config;
 mod error;
 
 use chrono::Duration;
@@ -10,6 +11,7 @@ use super::exchange_price_cache::ExchangePriceCache;
 
 use crate::ExchangePriceCacheConfig;
 pub use crate::{currency::*, fee_calculator::*};
+pub use config::*;
 pub use error::*;
 
 pub struct PriceApp {
@@ -20,6 +22,7 @@ pub struct PriceApp {
 impl PriceApp {
     pub async fn run(
         mut health_check_trigger: HealthCheckTrigger,
+        health_check_cfg: PriceServerHealthCheckConfig,
         fee_calc_cfg: FeeCalculatorConfig,
         pubsub_cfg: PubSubConfig,
         price_cache_config: ExchangePriceCacheConfig,
@@ -31,9 +34,7 @@ impl PriceApp {
                 check
                     .send(
                         subscriber
-                            .healthy(Duration::from_std(pubsub_cfg.last_msg_delay).expect(
-                                "Failed to convert std::time::Duration to chrono::time::Duration",
-                            ))
+                            .healthy(health_check_cfg.unhealthy_msg_interval_price)
                             .await,
                     )
                     .expect("Couldn't send response");

--- a/price-server/src/exchange_price_cache/config.rs
+++ b/price-server/src/exchange_price_cache/config.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+#[serde_with::serde_as]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ExchangePriceCacheConfig {
+    #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    #[serde(default = "default_stale_after_duration")]
+    pub stale_after: Duration,
+}
+
+fn default_stale_after_duration() -> Duration {
+    Duration::from_secs(30)
+}
+
+impl Default for ExchangePriceCacheConfig {
+    fn default() -> Self {
+        ExchangePriceCacheConfig {
+            stale_after: default_stale_after_duration(),
+        }
+    }
+}

--- a/price-server/src/exchange_price_cache/mod.rs
+++ b/price-server/src/exchange_price_cache/mod.rs
@@ -1,3 +1,5 @@
+pub mod config;
+
 use chrono::Duration;
 use opentelemetry::trace::{SpanContext, TraceContextExt};
 use std::sync::Arc;
@@ -13,6 +15,7 @@ use shared::{
 };
 
 use crate::currency::*;
+pub use config::*;
 
 #[derive(Error, Debug)]
 pub enum ExchangePriceCacheError {

--- a/price-server/src/lib.rs
+++ b/price-server/src/lib.rs
@@ -10,7 +10,7 @@ mod server;
 use shared::{health::HealthCheckTrigger, pubsub::PubSubConfig};
 
 use app::PriceApp;
-pub use exchange_price_cache::ExchangePriceCacheError;
+pub use exchange_price_cache::{ExchangePriceCacheConfig, ExchangePriceCacheError};
 pub use fee_calculator::FeeCalculatorConfig;
 pub use server::*;
 
@@ -19,8 +19,15 @@ pub async fn run(
     server_config: PriceServerConfig,
     fee_calc_cfg: FeeCalculatorConfig,
     pubsub_cfg: PubSubConfig,
+    price_cache_config: ExchangePriceCacheConfig,
 ) -> Result<(), PriceServerError> {
-    let app = PriceApp::run(health_check_trigger, fee_calc_cfg, pubsub_cfg).await?;
+    let app = PriceApp::run(
+        health_check_trigger,
+        fee_calc_cfg,
+        pubsub_cfg,
+        price_cache_config,
+    )
+    .await?;
 
     server::start(server_config, app).await?;
 

--- a/price-server/src/lib.rs
+++ b/price-server/src/lib.rs
@@ -10,12 +10,14 @@ mod server;
 use shared::{health::HealthCheckTrigger, pubsub::PubSubConfig};
 
 use app::PriceApp;
+pub use app::PriceServerHealthCheckConfig;
 pub use exchange_price_cache::{ExchangePriceCacheConfig, ExchangePriceCacheError};
 pub use fee_calculator::FeeCalculatorConfig;
 pub use server::*;
 
 pub async fn run(
     health_check_trigger: HealthCheckTrigger,
+    health_check_cfg: PriceServerHealthCheckConfig,
     server_config: PriceServerConfig,
     fee_calc_cfg: FeeCalculatorConfig,
     pubsub_cfg: PubSubConfig,
@@ -23,6 +25,7 @@ pub async fn run(
 ) -> Result<(), PriceServerError> {
     let app = PriceApp::run(
         health_check_trigger,
+        health_check_cfg,
         fee_calc_cfg,
         pubsub_cfg,
         price_cache_config,

--- a/price-server/src/order_book_cache.rs
+++ b/price-server/src/order_book_cache.rs
@@ -1,0 +1,221 @@
+use chrono::Duration;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use serde::Deserialize;
+use shared::{
+    payload::{OkexBtcUsdSwapOrderBookPayload, OrderBookPayload, PriceRaw},
+    pubsub::Envelope,
+    time::TimeStamp,
+};
+use std::{collections::BTreeMap, sync::Arc};
+use thiserror::Error;
+use tokio::sync::RwLock;
+
+use crate::VolumeBasedPriceConverter;
+
+#[derive(Debug, Error)]
+pub enum OrderBookCacheError {
+    #[error("PayloadConversion: conversion from OrderBookPayload failed")]
+    PayloadConversion,
+    #[error("OutdatedSnapshot: last update was at {0}")]
+    OutdatedSnapshot(TimeStamp),
+    #[error("No snapshot data available")]
+    NoSnapshotAvailable,
+    #[error("No price-quantity entry in asks or bids side")]
+    EmptySide,
+}
+
+#[derive(Debug, Clone)]
+pub struct OrderBookCache {
+    inner: Arc<RwLock<SnapshotInner>>,
+}
+impl OrderBookCache {
+    pub fn new(stale_after: Duration) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(SnapshotInner::new(stale_after))),
+        }
+    }
+
+    pub async fn apply_update(&self, snapshot: Envelope<OkexBtcUsdSwapOrderBookPayload>) {
+        self.inner.write().await.update_snapshot(snapshot);
+    }
+
+    pub async fn latest_snapshot(&self) -> Result<OrderBookView, OrderBookCacheError> {
+        let snap = self.inner.read().await.current()?;
+        Ok(snap)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SnapshotInner {
+    stale_after: Duration,
+    snapshot: Option<OrderBookView>,
+}
+impl SnapshotInner {
+    fn new(stale_after: Duration) -> Self {
+        Self {
+            stale_after,
+            snapshot: None,
+        }
+    }
+
+    fn update_snapshot(&mut self, snap: Envelope<OkexBtcUsdSwapOrderBookPayload>) {
+        let payload = snap.payload.0;
+
+        if let Some(ref snap) = self.snapshot {
+            if snap.timestamp > payload.timestamp {
+                return;
+            }
+        }
+
+        let snapshot = OrderBookView::from(payload);
+        self.snapshot = Some(snapshot);
+    }
+
+    fn current(&self) -> Result<OrderBookView, OrderBookCacheError> {
+        if let Some(ref snap) = self.snapshot {
+            if snap.timestamp.duration_since() > self.stale_after {
+                return Err(OrderBookCacheError::OutdatedSnapshot(snap.timestamp));
+            }
+
+            return Ok(snap.clone());
+        }
+
+        Err(OrderBookCacheError::NoSnapshotAvailable)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+pub struct QuotePrice(Decimal);
+impl From<PriceRaw> for QuotePrice {
+    fn from(price: PriceRaw) -> Self {
+        let price = price.into();
+
+        QuotePrice(price)
+    }
+}
+impl QuotePrice {
+    pub fn inner(&self) -> Decimal {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OrderBookView {
+    pub asks: BTreeMap<QuotePrice, Decimal>,
+    pub bids: BTreeMap<QuotePrice, Decimal>,
+    pub timestamp: TimeStamp,
+}
+impl From<OrderBookPayload> for OrderBookView {
+    fn from(value: OrderBookPayload) -> Self {
+        let asks = value
+            .asks
+            .into_iter()
+            .map(|(price, qty)| (QuotePrice::from(price), qty.into()))
+            .collect::<BTreeMap<QuotePrice, Decimal>>();
+
+        let bids = value
+            .bids
+            .into_iter()
+            .map(|(price, qty)| (QuotePrice::from(price), qty.into()))
+            .collect::<BTreeMap<QuotePrice, Decimal>>();
+
+        Self {
+            asks,
+            bids,
+            timestamp: value.timestamp,
+        }
+    }
+}
+
+impl OrderBookView {
+    pub fn sell_usd(
+        &self,
+    ) -> VolumeBasedPriceConverter<
+        std::collections::btree_map::Iter<QuotePrice, rust_decimal::Decimal>,
+    > {
+        VolumeBasedPriceConverter::new(self.asks.iter())
+    }
+
+    pub fn buy_usd(
+        &self,
+    ) -> VolumeBasedPriceConverter<
+        std::iter::Rev<std::collections::btree_map::Iter<QuotePrice, rust_decimal::Decimal>>,
+    > {
+        VolumeBasedPriceConverter::new(self.bids.iter().rev())
+    }
+
+    pub fn mid_price_of_one_sat(&self) -> Result<Decimal, OrderBookCacheError> {
+        let best_ask = self.best_ask_price_of_one_sat()?;
+        let best_bid = self.best_bid_price_of_one_sat()?;
+
+        Ok((best_ask + best_bid) / dec!(2))
+    }
+
+    fn best_bid_price_of_one_sat(&self) -> Result<Decimal, OrderBookCacheError> {
+        let bids_length = self.bids.iter().next_back();
+
+        let (best_price, _) = bids_length.ok_or(OrderBookCacheError::EmptySide)?;
+
+        Ok(best_price.inner())
+    }
+
+    fn best_ask_price_of_one_sat(&self) -> Result<Decimal, OrderBookCacheError> {
+        let ask_length = self.bids.iter().next();
+
+        let (best_price, _) = ask_length.ok_or(OrderBookCacheError::EmptySide)?;
+
+        Ok(best_price.inner())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use rust_decimal_macros::dec;
+    use shared::payload::{ExchangeIdRaw, QuantityRaw};
+
+    #[test]
+    fn convert_payload_to_snapshot() {
+        let mut bids = BTreeMap::new();
+        bids.insert(PriceRaw::from(dec!(100)), QuantityRaw::from(dec!(10)));
+        let mut asks = BTreeMap::new();
+        asks.insert(PriceRaw::from(dec!(100)), QuantityRaw::from(dec!(10)));
+
+        let payload = OrderBookPayload {
+            asks,
+            bids,
+            timestamp: TimeStamp::now(),
+            exchange: ExchangeIdRaw::from("okex".to_string()),
+        };
+
+        let lob_snapshot = OrderBookView::try_from(payload.clone())
+            .expect("payload conversion to snapshot failed");
+
+        assert_eq!(lob_snapshot.timestamp, payload.timestamp);
+        assert_eq!(lob_snapshot.asks.len(), payload.asks.len());
+    }
+
+    #[test]
+    fn mid_price() -> anyhow::Result<()> {
+        let mut asks = BTreeMap::new();
+        asks.insert(QuotePrice(dec!(10000)), dec!(10));
+        asks.insert(QuotePrice(dec!(15000)), dec!(10));
+
+        let mut bids = BTreeMap::new();
+        bids.insert(QuotePrice(dec!(5000)), dec!(10));
+        bids.insert(QuotePrice(dec!(10000)), dec!(10));
+
+        let snapshot = OrderBookView {
+            asks,
+            bids,
+            timestamp: TimeStamp::now(),
+        };
+        let mid_price = snapshot.mid_price_of_one_sat()?;
+
+        assert_eq!(mid_price, dec!(7500));
+
+        Ok(())
+    }
+}

--- a/price-server/src/price_converter/mod.rs
+++ b/price-server/src/price_converter/mod.rs
@@ -1,0 +1,145 @@
+use rust_decimal::Decimal;
+
+use crate::{
+    currency::{Sats, UsdCents},
+    QuotePrice,
+};
+
+pub struct VolumeBasedPriceConverter<'a, I: Iterator<Item = (&'a QuotePrice, &'a Decimal)> + Clone>
+{
+    pairs: I,
+}
+impl<'a, I: Iterator<Item = (&'a QuotePrice, &'a Decimal)> + Clone>
+    VolumeBasedPriceConverter<'a, I>
+{
+    pub fn new(pairs: I) -> Self {
+        Self { pairs }
+    }
+
+    pub fn cents_from_sats(&self, sats: Sats) -> UsdCents {
+        UsdCents::from_decimal(sats.amount() * self.weighted_price_of_volume(*sats.amount()))
+    }
+
+    pub fn sats_from_cents(&self, cents: UsdCents) -> Sats {
+        Sats::from_decimal(cents.amount() / self.weighted_price_of_volume(*cents.amount()))
+    }
+
+    fn weighted_price_of_volume(&self, total_volume: Decimal) -> Decimal {
+        let mut price_acc = Decimal::ZERO;
+        let mut volume_acc = Decimal::ZERO;
+
+        let pairs = self.pairs.clone();
+        for (price, qty) in pairs {
+            if (volume_acc + qty) < total_volume {
+                volume_acc += qty;
+                price_acc += price.inner() * qty;
+                continue;
+            } else {
+                let remaining_volume = total_volume - volume_acc;
+                price_acc += price.inner() * remaining_volume;
+                break;
+            }
+        }
+
+        price_acc / total_volume
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rust_decimal_macros::dec;
+    use serde::Deserialize;
+    use std::fs;
+
+    use crate::OrderBookView;
+
+    use super::*;
+
+    #[derive(Debug, Deserialize)]
+    struct SnapshotFixture {
+        payload: OrderBookView,
+    }
+
+    fn load_order_book(filename: &str) -> anyhow::Result<SnapshotFixture> {
+        let contents = fs::read_to_string(format!(
+            "./tests/fixtures/order-book-payload-{}.json",
+            filename
+        ))
+        .expect(&format!("Couldn't load fixture {}", filename));
+
+        let res = serde_json::from_str::<SnapshotFixture>(&contents)?;
+        Ok(res)
+    }
+
+    #[test]
+    fn weighted_average_ask_price() -> anyhow::Result<()> {
+        let latest_snapshot = load_order_book("real")?.payload;
+        let converter = VolumeBasedPriceConverter::new(latest_snapshot.asks.iter());
+        let volumes = vec![
+            Sats::from_decimal(dec!(1)),
+            Sats::from_decimal(dec!(10)),
+            Sats::from_decimal(dec!(20)),
+            Sats::from_decimal(dec!(100)),
+            Sats::from_decimal(dec!(110)),
+        ];
+        let expected_prices = vec![dec!(0.1), dec!(0.1), dec!(0.15), dec!(0.19), dec!(0.2)];
+
+        for (idx, sats) in volumes.into_iter().enumerate() {
+            let mut price = converter.weighted_price_of_volume(*sats.amount());
+            price.rescale(7);
+
+            assert_eq!(price, expected_prices[idx]);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn weighted_average_bid_price() -> anyhow::Result<()> {
+        let latest_snapshot = load_order_book("real")?.payload;
+        let converter = VolumeBasedPriceConverter::new(latest_snapshot.bids.iter().rev());
+        let volumes = vec![
+            Sats::from_decimal(dec!(1)),
+            Sats::from_decimal(dec!(10)),
+            Sats::from_decimal(dec!(20)),
+            Sats::from_decimal(dec!(100)),
+            Sats::from_decimal(dec!(200)),
+        ];
+        let expected_prices = vec![dec!(0.2), dec!(0.2), dec!(0.175), dec!(0.155), dec!(0.1275)];
+
+        for (idx, sats) in volumes.into_iter().enumerate() {
+            let mut price = converter.weighted_price_of_volume(*sats.amount());
+            price.rescale(7);
+
+            assert_eq!(price, expected_prices[idx]);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn cents_from_sats_volume() -> anyhow::Result<()> {
+        let latest_snapshot = load_order_book("real")?.payload;
+        let converter = VolumeBasedPriceConverter::new(latest_snapshot.bids.iter().rev());
+        let sats_volume = Sats::from_decimal(dec!(100_000_000));
+
+        let cents = converter.cents_from_sats(sats_volume);
+
+        assert_eq!(cents.floor(), UsdCents::from_major(65));
+
+        Ok(())
+    }
+
+    #[test]
+    fn sats_from_cents_volume() -> anyhow::Result<()> {
+        let latest_snapshot = load_order_book("real")?.payload;
+        let converter = VolumeBasedPriceConverter::new(latest_snapshot.bids.iter().rev());
+        let cents_volume = UsdCents::from_decimal(dec!(10));
+
+        let sats = converter.sats_from_cents(cents_volume);
+
+        assert_eq!(sats.floor(), Sats::from_major(50));
+
+        Ok(())
+    }
+}

--- a/price-server/src/server/convert.rs
+++ b/price-server/src/server/convert.rs
@@ -9,6 +9,9 @@ impl From<PriceAppError> for tonic::Status {
             ExchangePriceCacheError(err) => {
                 tonic::Status::new(tonic::Code::Unknown, format!("{}", err))
             }
+            StdDurationConversionError(err) => {
+                tonic::Status::new(tonic::Code::Unknown, format!("{}", err))
+            }
         }
     }
 }

--- a/price-server/tests/fixtures/order-book-payload-real.json
+++ b/price-server/tests/fixtures/order-book-payload-real.json
@@ -1,0 +1,21 @@
+{
+    "meta": {
+        "publishedAt": 1667454785,
+        "correlationId": "97b37536-e953-4c5b-821f-8058ae986080"
+    },
+    "payloadType": "OkexBtcUsdSwapOrderBookPayload",
+    "payload": {
+        "asks": {
+            "0.1": "10",
+            "0.2": "90",
+            "0.3": "1000"
+        },
+        "bids": {
+            "0.1": "500",
+            "0.15": "90",
+            "0.2": "10"
+        },
+        "timestamp": 1667454784,
+        "exchange": "okex"
+    }
+}

--- a/price-server/tests/price_app.rs
+++ b/price-server/tests/price_app.rs
@@ -30,6 +30,7 @@ async fn price_app() -> anyhow::Result<()> {
     let (_, recv) = futures::channel::mpsc::unbounded();
     let app = PriceApp::run(
         recv,
+        PriceServerHealthCheckConfig::default(),
         FeeCalculatorConfig {
             base_fee_rate: dec!(0.001),
             immediate_fee_rate: dec!(0.01),

--- a/price-server/tests/price_app.rs
+++ b/price-server/tests/price_app.rs
@@ -1,6 +1,6 @@
 use futures::stream::StreamExt;
 use rust_decimal_macros::dec;
-use std::fs;
+use std::{fs, time::Duration};
 
 use price_server::{app::*, *};
 use shared::{payload::*, pubsub::*, time::*};
@@ -36,6 +36,9 @@ async fn price_app() -> anyhow::Result<()> {
             delayed_fee_rate: dec!(0.1),
         },
         config,
+        ExchangePriceCacheConfig {
+            stale_after: Duration::from_secs(30),
+        },
     )
     .await?;
 

--- a/shared/src/pubsub/config.rs
+++ b/shared/src/pubsub/config.rs
@@ -14,6 +14,9 @@ pub struct PubSubConfig {
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
     #[serde(default = "default_throttle")]
     pub rate_limit_interval: Duration,
+    #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    #[serde(default = "default_last_msg_duration")]
+    pub last_msg_delay: Duration,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -38,6 +41,7 @@ impl Default for PubSubConfig {
             password: None,
             sentinel: None,
             rate_limit_interval: default_throttle(),
+            last_msg_delay: default_last_msg_duration(),
         }
     }
 }
@@ -56,6 +60,10 @@ fn default_throttle() -> Duration {
 
 fn default_service_name() -> String {
     "mymaster".to_string()
+}
+
+fn default_last_msg_duration() -> Duration {
+    Duration::from_secs(20)
 }
 
 impl From<PubSubConfig> for RedisConfig {

--- a/shared/src/pubsub/config.rs
+++ b/shared/src/pubsub/config.rs
@@ -14,9 +14,6 @@ pub struct PubSubConfig {
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
     #[serde(default = "default_throttle")]
     pub rate_limit_interval: Duration,
-    #[serde_as(as = "serde_with::DurationSeconds<u64>")]
-    #[serde(default = "default_last_msg_duration")]
-    pub last_msg_delay: Duration,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -41,7 +38,6 @@ impl Default for PubSubConfig {
             password: None,
             sentinel: None,
             rate_limit_interval: default_throttle(),
-            last_msg_delay: default_last_msg_duration(),
         }
     }
 }
@@ -60,10 +56,6 @@ fn default_throttle() -> Duration {
 
 fn default_service_name() -> String {
     "mymaster".to_string()
-}
-
-fn default_last_msg_duration() -> Duration {
-    Duration::from_secs(20)
 }
 
 impl From<PubSubConfig> for RedisConfig {

--- a/stablesats.yml
+++ b/stablesats.yml
@@ -3,6 +3,7 @@
 # pubsub:
   # host: localhost
   # rate_limit_duration: 2
+  # last_msg_delay: 20
 
 # galoy:
 #   api: galoy-endpoint
@@ -32,6 +33,8 @@
   #   base_fee_rate: 0.0005
   #   immediate_fee_rate: 0.0005
   #   delayed_fee_rate: 0.0007
+  # price_cache:
+  #   stale_after: 30
 
 # okex_price_feed:
   # enabled: true

--- a/stablesats.yml
+++ b/stablesats.yml
@@ -3,7 +3,6 @@
 # pubsub:
   # host: localhost
   # rate_limit_duration: 2
-  # last_msg_delay: 20
 
 # galoy:
 #   api: galoy-endpoint
@@ -15,6 +14,8 @@
 #     migrate_on_start: true
 #     balance_publish_frequency: 5
 #     galoy_poll_frequency: 5
+#     unhealthy_msg_interval_liability: 20
+#     unhealthy_msg_interval_position: 20
 #
 # hedging:
 #   enabled: true
@@ -29,6 +30,8 @@
   # enabled: true
   # server:
   #   listen_port: 3325
+  # health:
+  #   unhealthy_msg_interval_price: 20
   # fees:
   #   base_fee_rate: 0.0005
   #   immediate_fee_rate: 0.0005


### PR DESCRIPTION
## What this PR does
- configures the duration after which a price becomes stale
- configures the duration from when the last message was received by a subscriber
