### PR TITLE
chore: switch price feed to in-memory pubsub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1653,6 +1653,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
+ "serde_with",
  "stablesats-shared",
  "thiserror",
  "tokio",
@@ -2841,6 +2842,7 @@ version = "0.3.25-dev"
 dependencies = [
  "anyhow",
  "axum",
+ "chrono",
  "clap",
  "futures",
  "galoy-client",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -32,3 +32,4 @@ opentelemetry-jaeger = { version = "0.17.0", features = ["rt-tokio"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "json"] }
 tracing-opentelemetry = "0.18.0"
 axum = "0.6.1"
+chrono = "0.4.23"

--- a/hedging/src/lib.rs
+++ b/hedging/src/lib.rs
@@ -12,7 +12,7 @@ mod synth_usd_liability;
 
 use galoy_client::GaloyClientConfig;
 use okex_client::OkexClientConfig;
-use shared::{health::HealthCheckTrigger, pubsub::*};
+use shared::{health::HealthCheckTrigger, payload::*, pubsub::*};
 
 pub use app::*;
 pub use error::*;
@@ -23,6 +23,7 @@ pub async fn run(
     okex_config: OkexClientConfig,
     galoy_config: GaloyClientConfig,
     pubsub_cfg: PubSubConfig,
+    tick_receiver: memory::Subscriber<OkexBtcUsdSwapPricePayload>,
 ) -> Result<(), HedgingError> {
     HedgingApp::run(
         health_check_trigger,
@@ -30,6 +31,7 @@ pub async fn run(
         okex_config,
         galoy_config,
         pubsub_cfg,
+        tick_receiver,
     )
     .await?;
     Ok(())

--- a/hedging/tests/hedging.rs
+++ b/hedging/tests/hedging.rs
@@ -97,6 +97,9 @@ async fn expect_exposure_equal(
 #[tokio::test]
 #[serial]
 async fn hedging() -> anyhow::Result<()> {
+    let (_, tick_recv) = memory::channel(chrono::Duration::from_std(
+        std::time::Duration::from_secs(1),
+    )?);
     let redis_host = std::env::var("REDIS_HOST").unwrap_or("localhost".to_string());
     let pubsub_config = PubSubConfig {
         host: Some(redis_host),
@@ -126,6 +129,7 @@ async fn hedging() -> anyhow::Result<()> {
             okex_client_config(),
             galoy_client_config(),
             pubsub_config.clone(),
+            tick_recv.resubscribe(),
         )
         .await
         {
@@ -141,6 +145,7 @@ async fn hedging() -> anyhow::Result<()> {
                 okex_client_config(),
                 galoy_client_config(),
                 pubsub_config,
+                tick_recv,
             )
             .await
             .expect("Hedging app failed");

--- a/okex-price/Cargo.toml
+++ b/okex-price/Cargo.toml
@@ -22,6 +22,8 @@ tracing = "0.1.37"
 anyhow = "1.0.68"
 itertools = "0.10.5"
 crc32fast = "1.3.2"
+serde_with = "2.1.0"
+chrono = "0.4"
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["clock", "serde"], default-features = false }

--- a/okex-price/src/config.rs
+++ b/okex-price/src/config.rs
@@ -1,15 +1,30 @@
+use chrono::Duration;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+#[serde_with::serde_as]
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct PriceFeedConfig {
+    #[serde(default = "default_url")]
     pub url: Url,
+    #[serde_as(as = "serde_with::DurationSeconds<i64>")]
+    #[serde(default = "default_throttle")]
+    pub rate_limit_interval: Duration,
 }
 
 impl Default for PriceFeedConfig {
     fn default() -> Self {
         Self {
-            url: Url::parse("wss://ws.okx.com:8443/ws/v5/public").unwrap(),
+            url: default_url(),
+            rate_limit_interval: default_throttle(),
         }
     }
+}
+
+fn default_url() -> Url {
+    Url::parse("wss://ws.okx.com:8443/ws/v5/public").unwrap()
+}
+
+fn default_throttle() -> Duration {
+    Duration::from_std(std::time::Duration::from_secs(2)).unwrap()
 }

--- a/okex-price/src/error.rs
+++ b/okex-price/src/error.rs
@@ -1,9 +1,14 @@
 use serde_json::Error as SerdeError;
 use thiserror::Error;
+use tokio::sync::broadcast::error::SendError;
 use tokio_tungstenite::tungstenite::error::Error as TungsteniteError;
 
-use shared::pubsub::PublisherError;
+use shared::{
+    payload::*,
+    pubsub::{Envelope, PublisherError},
+};
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Error, Debug)]
 pub enum PriceFeedError {
     #[error("PriceFeedError - OkexWsError: {0}")]
@@ -18,6 +23,10 @@ pub enum PriceFeedError {
     SerializationError(#[from] SerdeError),
     #[error("PriceFeedError - PublisherError: {0}")]
     PublisherError(#[from] PublisherError),
+    #[error("PriceFeedError - TickPublishError: {0}")]
+    TickPublishErrorError(#[from] SendError<Envelope<OkexBtcUsdSwapPricePayload>>),
+    #[error("PriceFeedError - BookPublishError: {0}")]
+    BookPublishErrorError(#[from] SendError<Envelope<OkexBtcUsdSwapOrderBookPayload>>),
     #[error("PriceFeedError - OrderBookConversion: {0}")]
     OrderBookConversion(#[from] anyhow::Error),
     #[error("PriceFeedError - DepthValidation: {0}")]

--- a/okex-price/src/lib.rs
+++ b/okex-price/src/lib.rs
@@ -10,7 +10,7 @@ pub mod price_feed;
 
 use futures::StreamExt;
 use shared::{payload::*, pubsub::*};
-use tokio::{join, time::Duration};
+use tokio::join;
 
 pub use config::*;
 pub use error::*;
@@ -20,11 +20,8 @@ pub use price_feed::*;
 
 pub async fn run(
     price_feed_config: PriceFeedConfig,
-    pubsub_cfg: PubSubConfig,
+    ticks_publisher: memory::Publisher<OkexBtcUsdSwapPricePayload>,
 ) -> Result<(), PriceFeedError> {
-    let publisher = Publisher::new(pubsub_cfg.clone()).await?;
-
-    let ticks_publisher = publisher.clone();
     let pf_config = price_feed_config.clone();
     let mut stream = subscribe_btc_usd_swap_price_tick(pf_config).await?;
 
@@ -34,20 +31,22 @@ pub async fn run(
         }
     });
 
-    let order_book_task = tokio::spawn(async move {
-        loop {
-            let _res = order_book_subscription(publisher.clone(), &price_feed_config).await;
-            tokio::time::sleep(Duration::from_secs(5_u64)).await;
-        }
-    });
+    // let order_book_task = tokio::spawn(async move {
+    //     loop {
+    //         let _res = order_book_subscription(books_publisher.clone(), &price_feed_config).await;
+    //         tokio::time::sleep(Duration::from_secs(5_u64)).await;
+    //     }
+    // });
 
-    let _ = join!(tick_task, order_book_task);
+    // let _ = join!(tick_task, order_book_task);
+    let _ = join!(tick_task);
 
     Ok(())
 }
 
+#[allow(dead_code)]
 async fn order_book_subscription(
-    publisher: Publisher,
+    publisher: memory::Publisher<OkexBtcUsdSwapOrderBookPayload>,
     config: &PriceFeedConfig,
 ) -> Result<(), PriceFeedError> {
     let mut stream = subscribe_btc_usd_swap_order_book(config.clone()).await?;
@@ -70,7 +69,7 @@ async fn order_book_subscription(
 }
 
 async fn okex_price_tick_received(
-    publisher: &Publisher,
+    publisher: &memory::Publisher<OkexBtcUsdSwapPricePayload>,
     tick: OkexPriceTick,
 ) -> Result<(), PriceFeedError> {
     if let Ok(payload) = OkexBtcUsdSwapPricePayload::try_from(tick) {
@@ -79,8 +78,9 @@ async fn okex_price_tick_received(
     Ok(())
 }
 
+#[allow(dead_code)]
 async fn okex_order_book_received(
-    publisher: &Publisher,
+    publisher: &memory::Publisher<OkexBtcUsdSwapOrderBookPayload>,
     book: OkexOrderBook,
     mut cache: OrderBookCache,
 ) -> Result<(), PriceFeedError> {

--- a/okex-price/src/order_book/mod.rs
+++ b/okex-price/src/order_book/mod.rs
@@ -8,7 +8,7 @@ use super::{config::*, error::*};
 pub use book::*;
 
 pub async fn subscribe_btc_usd_swap_order_book(
-    PriceFeedConfig { url }: PriceFeedConfig,
+    PriceFeedConfig { url, .. }: PriceFeedConfig,
 ) -> Result<Pin<Box<dyn Stream<Item = OkexOrderBook> + Send>>, PriceFeedError> {
     let (ws_stream, _ws_sink) = connect_async(url).await?;
     let (mut sender, receiver) = ws_stream.split();

--- a/okex-price/tests/price_feed.rs
+++ b/okex-price/tests/price_feed.rs
@@ -2,7 +2,6 @@ use chrono::Duration;
 use futures::StreamExt;
 use okex_price::*;
 use std::fs;
-use url::Url;
 
 use shared::{payload::*, pubsub::*, time::*};
 
@@ -19,9 +18,7 @@ fn load_fixture() -> anyhow::Result<Fixture> {
 
 #[tokio::test]
 async fn subscribes_to_tickers_channel() -> anyhow::Result<()> {
-    let config = PriceFeedConfig {
-        url: Url::parse("wss://ws.okx.com:8443/ws/v5/public").unwrap(),
-    };
+    let config = PriceFeedConfig::default();
     let mut received = subscribe_btc_usd_swap_price_tick(config)
         .await
         .expect("subscribe_btc_usd_swap");
@@ -47,9 +44,7 @@ async fn subscribes_to_tickers_channel() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn subscribe_to_order_book_channel() -> anyhow::Result<()> {
-    let config = PriceFeedConfig {
-        url: Url::parse("wss://ws.okx.com:8443/ws/v5/public").unwrap(),
-    };
+    let config = PriceFeedConfig::default();
     let mut order_book_stream = subscribe_btc_usd_swap_order_book(config)
         .await
         .expect("subscribe to order book channel");
@@ -71,30 +66,18 @@ async fn subscribe_to_order_book_channel() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn publishes_to_redis() -> anyhow::Result<()> {
-    let redis_host = std::env::var("REDIS_HOST").unwrap_or("localhost".to_string());
-    let pubsub_config = PubSubConfig {
-        host: Some(redis_host),
-        ..PubSubConfig::default()
-    };
-    let mut subscriber = Subscriber::new(pubsub_config.clone()).await?;
+    let (tick_send, mut tick_recv) =
+        memory::channel(chrono::Duration::from_std(std::time::Duration::from_secs(2)).unwrap());
 
     let _ = tokio::spawn(async move {
-        let _res = okex_price::run(PriceFeedConfig::default(), pubsub_config).await;
+        let _res = okex_price::run(PriceFeedConfig::default(), tick_send).await;
     });
 
-    let mut tick_stream = subscriber.subscribe::<OkexBtcUsdSwapPricePayload>().await?;
-    let mut book_stream = subscriber
-        .subscribe::<OkexBtcUsdSwapOrderBookPayload>()
-        .await?;
-
-    let received_tick = tick_stream.next().await.expect("expected price tick");
-    let received_book = book_stream.next().await.expect("expected price snapshot");
+    let received_tick = tick_recv.next().await.expect("expected price tick");
 
     let payload = &load_fixture()?.payloads[0];
     assert_eq!(received_tick.payload.exchange, payload.exchange);
     assert_eq!(received_tick.payload.instrument_id, payload.instrument_id);
-    assert_eq!(received_book.payload.exchange, payload.exchange);
-    assert!(received_book.payload.asks.len() >= 400);
 
     Ok(())
 }

--- a/price-server/src/lib.rs
+++ b/price-server/src/lib.rs
@@ -7,7 +7,7 @@ mod exchange_price_cache;
 mod fee_calculator;
 mod server;
 
-use shared::{health::HealthCheckTrigger, pubsub::PubSubConfig};
+use shared::{health::HealthCheckTrigger, payload::*, pubsub::memory};
 
 use app::PriceApp;
 pub use app::PriceServerHealthCheckConfig;
@@ -20,14 +20,14 @@ pub async fn run(
     health_check_cfg: PriceServerHealthCheckConfig,
     server_config: PriceServerConfig,
     fee_calc_cfg: FeeCalculatorConfig,
-    pubsub_cfg: PubSubConfig,
+    subscriber: memory::Subscriber<OkexBtcUsdSwapPricePayload>,
     price_cache_config: ExchangePriceCacheConfig,
 ) -> Result<(), PriceServerError> {
     let app = PriceApp::run(
         health_check_trigger,
         health_check_cfg,
         fee_calc_cfg,
-        pubsub_cfg,
+        subscriber,
         price_cache_config,
     )
     .await?;

--- a/shared/src/pubsub/memory.rs
+++ b/shared/src/pubsub/memory.rs
@@ -1,0 +1,142 @@
+use futures::{channel::mpsc::*, stream::StreamExt, SinkExt};
+use governor::{clock::DefaultClock, state::InMemoryState, state::NotKeyed, Quota, RateLimiter};
+use tokio::sync::{broadcast, RwLock};
+use tracing::instrument;
+
+use std::{num::NonZeroU32, sync::Arc};
+
+use super::message::*;
+use crate::{health::HealthCheckResponse, time::TimeStamp};
+
+const MAX_BURST: u32 = 1;
+
+pub fn channel<P: MessagePayload>(
+    rate_limit_interval: chrono::Duration,
+) -> (Publisher<P>, Subscriber<P>) {
+    let (tx, rx) = broadcast::channel(1);
+    let rate_limiter = Arc::new(RateLimiter::direct(
+        Quota::with_period(
+            rate_limit_interval
+                .to_std()
+                .expect("Could not convert to std"),
+        )
+        .expect("couldn't create quota")
+        .allow_burst(NonZeroU32::new(MAX_BURST).unwrap()),
+    ));
+    let last_msg_timestamp = Arc::new(RwLock::new(None));
+    let ts = Arc::clone(&last_msg_timestamp);
+    let (timestamp_sender, mut rcv) = unbounded();
+    tokio::spawn(async move {
+        while let Some(timestamp) = rcv.next().await {
+            let mut last_ts = ts.write().await;
+            if last_ts.unwrap_or(timestamp) <= timestamp {
+                *last_ts = Some(timestamp);
+            }
+        }
+    });
+    (
+        Publisher {
+            inner: tx,
+            rate_limiter,
+        },
+        Subscriber {
+            inner: rx,
+            last_msg_timestamp,
+            timestamp_sender,
+        },
+    )
+}
+
+#[derive(Clone)]
+pub struct Publisher<P: MessagePayload> {
+    inner: broadcast::Sender<Envelope<P>>,
+    rate_limiter: Arc<RateLimiter<NotKeyed, InMemoryState, DefaultClock>>,
+}
+
+impl<P: MessagePayload> Publisher<P> {
+    pub async fn throttle_publish(
+        &self,
+        payload: P,
+    ) -> Result<bool, broadcast::error::SendError<Envelope<P>>> {
+        if self.rate_limiter.check().is_ok() {
+            self.publish(payload).await?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    #[instrument(skip_all, fields(correlation_id, payload_type, payload_json, error, error.message), err)]
+    pub async fn publish(
+        &self,
+        payload: P,
+    ) -> Result<(), broadcast::error::SendError<Envelope<P>>> {
+        let span = tracing::Span::current();
+        span.record(
+            "payload_type",
+            &tracing::field::display(<P as MessagePayload>::message_type()),
+        );
+        span.record(
+            "payload_json",
+            &tracing::field::display(serde_json::to_string(&payload).expect("Could not serialize")),
+        );
+        let msg = Envelope::new(payload);
+        span.record(
+            "published_at",
+            &tracing::field::display(&msg.meta.published_at),
+        );
+
+        crate::tracing::record_error(tracing::Level::WARN, || async move { self.inner.send(msg) })
+            .await?;
+        Ok(())
+    }
+}
+
+pub struct Subscriber<P: MessagePayload> {
+    inner: broadcast::Receiver<Envelope<P>>,
+    last_msg_timestamp: Arc<RwLock<Option<TimeStamp>>>,
+    timestamp_sender: UnboundedSender<TimeStamp>,
+}
+
+impl<P: MessagePayload> Subscriber<P> {
+    pub fn resubscribe(&self) -> Self {
+        Self {
+            inner: self.inner.resubscribe(),
+            last_msg_timestamp: Arc::clone(&self.last_msg_timestamp),
+            timestamp_sender: self.timestamp_sender.clone(),
+        }
+    }
+
+    pub async fn next(&mut self) -> Option<Envelope<P>> {
+        loop {
+            match self.inner.recv().await {
+                Ok(msg) => {
+                    let _ = self.timestamp_sender.send(msg.meta.published_at);
+                    return Some(msg);
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+            }
+        }
+    }
+
+    pub async fn healthy(&self, largest_msg_delay: chrono::Duration) -> HealthCheckResponse {
+        let last_msg_timestamp = self.last_msg_timestamp.read().await;
+        if let Some(time_since) = last_msg_timestamp.map(|ts| ts.duration_since()) {
+            if time_since <= largest_msg_delay {
+                Ok(())
+            } else {
+                Err(format!(
+                    "No '{}' messages received in the last {} seconds",
+                    <P as MessagePayload>::message_type(),
+                    time_since.num_seconds()
+                ))
+            }
+        } else {
+            Err(format!(
+                "No '{}' messages received",
+                <P as MessagePayload>::message_type()
+            ))
+        }
+    }
+}

--- a/shared/src/pubsub/mod.rs
+++ b/shared/src/pubsub/mod.rs
@@ -1,5 +1,6 @@
 mod config;
 mod error;
+pub mod memory;
 mod message;
 mod publisher;
 mod subscriber;


### PR DESCRIPTION
Due to operational issues that keep coming up in regards to Redis we are moving towards an in-memory pubsub implementation. This sacrifices some scalability for better ops.

Should the need to scale come eventually we can always shift back.

As a first step this PR switches out the pubsub implementation just for the okex price feed. This is the stream that is the most flaky in production and so it could be a quick win. If things behave as expected we can easily implement more.