### PR TITLE
fix!: re-import galoy-transactions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test-in-ci:
 	SQLX_OFFLINE=true cargo nextest run --verbose --locked
 
 cli-run:
-	cargo run --bin stablesats run
+	SQLX_OFFLINE=true cargo run --bin stablesats run
 
 build-x86_64-unknown-linux-musl-release:
 	SQLX_OFFLINE=true cargo build --release --locked --target x86_64-unknown-linux-musl

--- a/galoy-client/src/client/convert.rs
+++ b/galoy-client/src/client/convert.rs
@@ -115,6 +115,8 @@ impl TryFrom<stablesats_transactions_list::ResponseData> for GaloyTransactions {
                     settlement_currency: edge.node.settlement_currency,
                     settlement_method: edge.node.settlement_via,
                     cents_per_unit,
+                    memo: edge.node.memo,
+                    direction: edge.node.direction,
                     status: edge.node.status,
                 }
             })

--- a/galoy-client/src/client/transaction.rs
+++ b/galoy-client/src/client/transaction.rs
@@ -20,6 +20,7 @@ pub type GaloyTransactionEdge =
     stablesats_transactions_list::StablesatsTransactionsListMeDefaultAccountTransactionsEdges;
 pub type GaloyTransactionNode =
     stablesats_transactions_list::StablesatsTransactionsListMeDefaultAccountTransactionsEdgesNode;
+pub type TxDirection = stablesats_transactions_list::TxDirection;
 
 pub type SettlementCurrency = stablesats_transactions_list::WalletCurrency;
 impl std::fmt::Display for SettlementCurrency {
@@ -54,6 +55,16 @@ impl std::fmt::Display for SettlementMethod {
     }
 }
 
+impl std::fmt::Display for TxDirection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RECEIVE => write!(f, "RECEIVE"),
+            Self::SEND => write!(f, "SEND"),
+            Self::Other(other) => write!(f, "{other}"),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct GaloyTransaction {
     pub id: String,
@@ -61,6 +72,8 @@ pub struct GaloyTransaction {
     pub settlement_amount: Decimal,
     pub settlement_currency: SettlementCurrency,
     pub settlement_method: SettlementMethod,
+    pub memo: Option<String>,
+    pub direction: TxDirection,
     pub cents_per_unit: Decimal,
     pub amount_in_usd_cents: Decimal,
     pub status: TxStatus,

--- a/ledger/src/constants.rs
+++ b/ledger/src/constants.rs
@@ -5,8 +5,12 @@ use uuid::{uuid, Uuid};
 // Templates
 pub(super) const USER_BUYS_USD_CODE: &str = "USER_BUYS_USD";
 pub(super) const USER_BUYS_USD_ID: Uuid = uuid!("00000000-0000-0000-0000-000000000001");
+pub(super) const REVERT_USER_BUYS_USD_CODE: &str = "REVERT_USER_BUYS_USD";
+pub(super) const REVERT_USER_BUYS_USD_ID: Uuid = uuid!("00000000-0000-0000-0000-100000000001");
 pub(super) const USER_SELLS_USD_CODE: &str = "USER_SELLS_USD";
 pub(super) const USER_SELLS_USD_ID: Uuid = uuid!("00000000-0000-0000-0000-000000000002");
+pub(super) const REVERT_USER_SELLS_USD_CODE: &str = "REVERT_USER_SELLS_USD";
+pub(super) const REVERT_USER_SELLS_USD_ID: Uuid = uuid!("00000000-0000-0000-0000-100000000002");
 
 // Journal
 pub(super) const STABLESATS_JOURNAL_NAME: &str = "Stablesats";

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -48,6 +48,8 @@ impl Ledger {
 
         templates::UserBuysUsd::init(&inner).await?;
         templates::UserSellsUsd::init(&inner).await?;
+        templates::RevertUserBuysUsd::init(&inner).await?;
+        templates::RevertUserSellsUsd::init(&inner).await?;
 
         Ok(Self {
             events: inner.events(DEFAULT_BUFFER_SIZE).await?,
@@ -87,6 +89,32 @@ impl Ledger {
     ) -> Result<(), LedgerError> {
         self.inner
             .post_transaction_in_tx(tx, id, USER_SELLS_USD_CODE, Some(params))
+            .await?;
+        Ok(())
+    }
+
+    #[instrument(name = "ledger.revert_user_buys_usd", skip(self, tx))]
+    pub async fn revert_user_buys_usd(
+        &self,
+        tx: Transaction<'_, Postgres>,
+        id: LedgerTxId,
+        params: RevertUserBuysUsdParams,
+    ) -> Result<(), LedgerError> {
+        self.inner
+            .post_transaction_in_tx(tx, id, REVERT_USER_BUYS_USD_CODE, Some(params))
+            .await?;
+        Ok(())
+    }
+
+    #[instrument(name = "ledger.revert_user_sells_usd", skip(self, tx))]
+    pub async fn revert_user_sells_usd(
+        &self,
+        tx: Transaction<'_, Postgres>,
+        id: LedgerTxId,
+        params: RevertUserSellsUsdParams,
+    ) -> Result<(), LedgerError> {
+        self.inner
+            .post_transaction_in_tx(tx, id, REVERT_USER_SELLS_USD_CODE, Some(params))
             .await?;
         Ok(())
     }

--- a/ledger/src/templates/mod.rs
+++ b/ledger/src/templates/mod.rs
@@ -1,5 +1,9 @@
+mod revert_user_buys_usd;
+mod revert_user_sells_usd;
 mod user_buys_usd;
 mod user_sells_usd;
 
+pub use revert_user_buys_usd::*;
+pub use revert_user_sells_usd::*;
 pub use user_buys_usd::*;
 pub use user_sells_usd::*;

--- a/ledger/src/templates/revert_user_buys_usd.rs
+++ b/ledger/src/templates/revert_user_buys_usd.rs
@@ -1,0 +1,142 @@
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use sqlx_ledger::{tx_template::*, SqlxLedger, SqlxLedgerError, TransactionId as LedgerTxId};
+use tracing::instrument;
+
+use crate::{constants::*, error::*};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RevertUserBuysUsdMeta {
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub timestamp: DateTime<Utc>,
+    pub btc_tx_id: String,
+    pub usd_tx_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RevertUserBuysUsdParams {
+    pub satoshi_amount: Decimal,
+    pub usd_cents_amount: Decimal,
+    pub initial_ledger_tx_id: LedgerTxId,
+    pub meta: RevertUserBuysUsdMeta,
+}
+impl RevertUserBuysUsdParams {
+    pub fn defs() -> Vec<ParamDefinition> {
+        vec![
+            ParamDefinition::builder()
+                .name("btc_amount")
+                .r#type(ParamDataType::DECIMAL)
+                .build()
+                .unwrap(),
+            ParamDefinition::builder()
+                .name("usd_amount")
+                .r#type(ParamDataType::DECIMAL)
+                .build()
+                .unwrap(),
+            ParamDefinition::builder()
+                .name("correlation_id")
+                .r#type(ParamDataType::UUID)
+                .build()
+                .unwrap(),
+            ParamDefinition::builder()
+                .name("meta")
+                .r#type(ParamDataType::JSON)
+                .build()
+                .unwrap(),
+            ParamDefinition::builder()
+                .name("effective")
+                .r#type(ParamDataType::DATE)
+                .build()
+                .unwrap(),
+        ]
+    }
+}
+
+impl From<RevertUserBuysUsdParams> for TxParams {
+    fn from(
+        RevertUserBuysUsdParams {
+            satoshi_amount,
+            usd_cents_amount,
+            initial_ledger_tx_id,
+            meta,
+        }: RevertUserBuysUsdParams,
+    ) -> Self {
+        let effective = meta.timestamp.naive_utc().date();
+        let meta = serde_json::to_value(meta).expect("Couldn't serialize meta");
+        let mut params = Self::default();
+        params.insert("btc_amount", satoshi_amount / SATS_PER_BTC);
+        params.insert("usd_amount", usd_cents_amount / CENTS_PER_USD);
+        params.insert("correlation_id", initial_ledger_tx_id);
+        params.insert("meta", meta);
+        params.insert("effective", effective);
+        params
+    }
+}
+pub struct RevertUserBuysUsd {}
+
+impl RevertUserBuysUsd {
+    #[instrument(name = "ledger.revert_user_buys_usd.init", skip_all)]
+    pub async fn init(ledger: &SqlxLedger) -> Result<(), LedgerError> {
+        let tx_input = TxInput::builder()
+            .journal_id(format!("uuid('{STABLESATS_JOURNAL_ID}')"))
+            .effective("params.effective")
+            .correlation_id("params.correlation_id")
+            .metadata("params.meta")
+            .description("'User buys USD'")
+            .build()
+            .expect("Couldn't build TxInput");
+        let entries = vec![
+            EntryInput::builder()
+                .entry_type("'REVERT_USER_BUYS_USD_BTC_CR'")
+                .currency("'BTC'")
+                .account_id(format!("uuid('{STABLESATS_BTC_WALLET_ID}')"))
+                .direction("CREDIT")
+                .layer("SETTLED")
+                .units("params.btc_amount * -1")
+                .build()
+                .expect("Couldn't build REVERT_USER_BUYS_USD_BTC_CR entry"),
+            EntryInput::builder()
+                .entry_type("'REVERT_USER_BUYS_USD_BTC_DR'")
+                .currency("'BTC'")
+                .account_id(format!("uuid('{EXTERNAL_OMNIBUS_ID}')"))
+                .direction("DEBIT")
+                .layer("SETTLED")
+                .units("params.btc_amount * -1")
+                .build()
+                .expect("Couldn't build REVERT_USER_BUYS_USD_BTC_DR entry"),
+            EntryInput::builder()
+                .entry_type("'REVERT_USER_BUYS_USD_USD_CR'")
+                .currency("'USD'")
+                .account_id(format!("uuid('{STABLESATS_LIABILITY_ID}')"))
+                .direction("CREDIT")
+                .layer("SETTLED")
+                .units("params.usd_amount * -1")
+                .build()
+                .expect("Couldn't build REVERT_USER_BUYS_USD_USD_CR entry"),
+            EntryInput::builder()
+                .entry_type("'REVERT_USER_BUYS_USD_USD_DR'")
+                .currency("'USD'")
+                .account_id(format!("uuid('{STABLESATS_OMNIBUS_ID}')"))
+                .direction("DEBIT")
+                .layer("SETTLED")
+                .units("params.usd_amount * -1")
+                .build()
+                .expect("Couldn't build REVERT_USER_BUYS_USD_USD_DR entry"),
+        ];
+
+        let params = RevertUserBuysUsdParams::defs();
+        let template = NewTxTemplate::builder()
+            .id(REVERT_USER_BUYS_USD_ID)
+            .code(REVERT_USER_BUYS_USD_CODE)
+            .tx_input(tx_input)
+            .entries(entries)
+            .params(params)
+            .build()
+            .expect("Couldn't build REVERT_USER_BUYS_USD_CODE");
+        match ledger.tx_templates().create(template).await {
+            Ok(_) | Err(SqlxLedgerError::DuplicateKey(_)) => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+}

--- a/ledger/src/templates/revert_user_buys_usd.rs
+++ b/ledger/src/templates/revert_user_buys_usd.rs
@@ -83,7 +83,7 @@ impl RevertUserBuysUsd {
             .effective("params.effective")
             .correlation_id("params.correlation_id")
             .metadata("params.meta")
-            .description("'User buys USD'")
+            .description("'REVERT: User buys USD'")
             .build()
             .expect("Couldn't build TxInput");
         let entries = vec![

--- a/ledger/src/templates/revert_user_sells_usd.rs
+++ b/ledger/src/templates/revert_user_sells_usd.rs
@@ -1,0 +1,142 @@
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use sqlx_ledger::{tx_template::*, SqlxLedger, SqlxLedgerError, TransactionId as LedgerTxId};
+use tracing::instrument;
+
+use crate::{constants::*, error::*};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RevertUserSellsUsdMeta {
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub timestamp: DateTime<Utc>,
+    pub btc_tx_id: String,
+    pub usd_tx_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RevertUserSellsUsdParams {
+    pub satoshi_amount: Decimal,
+    pub usd_cents_amount: Decimal,
+    pub initial_ledger_tx_id: LedgerTxId,
+    pub meta: RevertUserSellsUsdMeta,
+}
+impl RevertUserSellsUsdParams {
+    pub fn defs() -> Vec<ParamDefinition> {
+        vec![
+            ParamDefinition::builder()
+                .name("btc_amount")
+                .r#type(ParamDataType::DECIMAL)
+                .build()
+                .unwrap(),
+            ParamDefinition::builder()
+                .name("usd_amount")
+                .r#type(ParamDataType::DECIMAL)
+                .build()
+                .unwrap(),
+            ParamDefinition::builder()
+                .name("correlation_id")
+                .r#type(ParamDataType::UUID)
+                .build()
+                .unwrap(),
+            ParamDefinition::builder()
+                .name("meta")
+                .r#type(ParamDataType::JSON)
+                .build()
+                .unwrap(),
+            ParamDefinition::builder()
+                .name("effective")
+                .r#type(ParamDataType::DATE)
+                .build()
+                .unwrap(),
+        ]
+    }
+}
+
+impl From<RevertUserSellsUsdParams> for TxParams {
+    fn from(
+        RevertUserSellsUsdParams {
+            satoshi_amount,
+            usd_cents_amount,
+            initial_ledger_tx_id,
+            meta,
+        }: RevertUserSellsUsdParams,
+    ) -> Self {
+        let effective = meta.timestamp.naive_utc().date();
+        let meta = serde_json::to_value(meta).expect("Couldn't serialize meta");
+        let mut params = Self::default();
+        params.insert("btc_amount", satoshi_amount / SATS_PER_BTC);
+        params.insert("usd_amount", usd_cents_amount / CENTS_PER_USD);
+        params.insert("correlation_id", initial_ledger_tx_id);
+        params.insert("meta", meta);
+        params.insert("effective", effective);
+        params
+    }
+}
+pub struct RevertUserSellsUsd {}
+
+impl RevertUserSellsUsd {
+    #[instrument(name = "ledger.user_sells_usd.init", skip_all)]
+    pub async fn init(ledger: &SqlxLedger) -> Result<(), LedgerError> {
+        let tx_input = TxInput::builder()
+            .journal_id(format!("uuid('{STABLESATS_JOURNAL_ID}')"))
+            .effective("params.effective")
+            .correlation_id("params.correlation_id")
+            .metadata("params.meta")
+            .description("'User sells USD'")
+            .build()
+            .expect("Couldn't build TxInput");
+        let entries = vec![
+            EntryInput::builder()
+                .entry_type("'REVERT_USER_SELLS_USD_BTC_DR'")
+                .currency("'BTC'")
+                .account_id(format!("uuid('{STABLESATS_BTC_WALLET_ID}')"))
+                .direction("DEBIT")
+                .layer("SETTLED")
+                .units("params.btc_amount * -1")
+                .build()
+                .expect("Couldn't build REVERT_USER_SELLS_USD_BTC_DR entry"),
+            EntryInput::builder()
+                .entry_type("'REVERT_USER_SELLS_USD_BTC_CR'")
+                .currency("'BTC'")
+                .account_id(format!("uuid('{EXTERNAL_OMNIBUS_ID}')"))
+                .direction("CREDIT")
+                .layer("SETTLED")
+                .units("params.btc_amount * -1")
+                .build()
+                .expect("Couldn't build REVERT_USER_SELLS_USD_BTC_CR entry"),
+            EntryInput::builder()
+                .entry_type("'REVERT_USER_SELLS_USD_USD_DR'")
+                .currency("'USD'")
+                .account_id(format!("uuid('{STABLESATS_LIABILITY_ID}')"))
+                .direction("DEBIT")
+                .layer("SETTLED")
+                .units("params.usd_amount * -1")
+                .build()
+                .expect("Couldn't build REVERT_USER_SELLS_USD_USD_DR entry"),
+            EntryInput::builder()
+                .entry_type("'REVERT_USER_SELLS_USD_USD_CR'")
+                .currency("'USD'")
+                .account_id(format!("uuid('{STABLESATS_OMNIBUS_ID}')"))
+                .direction("CREDIT")
+                .layer("SETTLED")
+                .units("params.usd_amount * -1")
+                .build()
+                .expect("Couldn't build REVERT_USER_SELLS_USD_USD_CR entry"),
+        ];
+
+        let params = RevertUserSellsUsdParams::defs();
+        let template = NewTxTemplate::builder()
+            .id(REVERT_USER_SELLS_USD_ID)
+            .code(REVERT_USER_SELLS_USD_CODE)
+            .tx_input(tx_input)
+            .entries(entries)
+            .params(params)
+            .build()
+            .expect("Couldn't build REVERT_USER_SELLS_USD_CODE");
+        match ledger.tx_templates().create(template).await {
+            Ok(_) | Err(SqlxLedgerError::DuplicateKey(_)) => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+}

--- a/ledger/src/templates/revert_user_sells_usd.rs
+++ b/ledger/src/templates/revert_user_sells_usd.rs
@@ -83,7 +83,7 @@ impl RevertUserSellsUsd {
             .effective("params.effective")
             .correlation_id("params.correlation_id")
             .metadata("params.meta")
-            .description("'User sells USD'")
+            .description("'REVERT: User sells USD'")
             .build()
             .expect("Couldn't build TxInput");
         let entries = vec![

--- a/migrations/20230222080947_reset-galoy-transactions.down.sql
+++ b/migrations/20230222080947_reset-galoy-transactions.down.sql
@@ -1,1 +1,0 @@
--- Add down migration script here

--- a/migrations/20230222080947_reset-galoy-transactions.down.sql
+++ b/migrations/20230222080947_reset-galoy-transactions.down.sql
@@ -1,0 +1,1 @@
+-- Add down migration script here

--- a/migrations/20230222080947_reset-galoy-transactions.up.sql
+++ b/migrations/20230222080947_reset-galoy-transactions.up.sql
@@ -1,0 +1,15 @@
+DROP TABLE galoy_transactions;
+
+CREATE TABLE galoy_transactions (
+  id VARCHAR(60) UNIQUE PRIMARY KEY,
+  cursor VARCHAR(60) NOT NULL,
+  is_paired BOOLEAN,
+  settlement_amount NUMERIC NOT NULL,
+  settlement_currency VARCHAR(10) NOT NULL,
+  settlement_method VARCHAR(60) NOT NULL,
+  direction VARCHAR NOT NULL,
+  memo VARCHAR,
+  cents_per_unit NUMERIC NOT NULL,
+  amount_in_usd_cents NUMERIC NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL
+);

--- a/migrations/20230222080947_reset-galoy-transactions.up.sql
+++ b/migrations/20230222080947_reset-galoy-transactions.up.sql
@@ -1,7 +1,7 @@
 DROP TABLE galoy_transactions;
 
 CREATE TABLE galoy_transactions (
-  id VARCHAR(60) UNIQUE PRIMARY KEY,
+  id VARCHAR(60) PRIMARY KEY,
   cursor VARCHAR(60) NOT NULL,
   is_paired BOOLEAN,
   settlement_amount NUMERIC NOT NULL,

--- a/migrations/20230222080947_reset-galoy-transactions.up.sql
+++ b/migrations/20230222080947_reset-galoy-transactions.up.sql
@@ -13,3 +13,5 @@ CREATE TABLE galoy_transactions (
   amount_in_usd_cents NUMERIC NOT NULL,
   created_at TIMESTAMP WITH TIME ZONE NOT NULL
 );
+
+ALTER TABLE user_trades ADD COLUMN correction_ledger_tx_id UUID DEFAULT NULL;

--- a/user-trades/sqlx-data.json
+++ b/user-trades/sqlx-data.json
@@ -1,18 +1,6 @@
 {
   "db": "PostgreSQL",
-  "21fff44c3d9afbeb410e20503d5503ed369d2e1e973d7240ea7e6db64d15af9d": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Left": [
-          "TextArray"
-        ]
-      }
-    },
-    "query": "UPDATE galoy_transactions SET is_paired = 'true' WHERE id = ANY($1)"
-  },
-  "2ab6719038a358bdeb8020ed6c84b8b8b79f1562b82987082e32f113d029ab9c": {
+  "05219fc1273ea7a34b9b582be067d1ba065ce4e7cc4bd1b5af7f520bb36aff44": {
     "describe": {
       "columns": [
         {
@@ -26,14 +14,14 @@
           "type_info": "Varchar"
         },
         {
-          "name": "memo",
+          "name": "amount_in_usd_cents",
           "ordinal": 2,
-          "type_info": "Varchar"
+          "type_info": "Numeric"
         },
         {
-          "name": "amount_in_usd_cents",
+          "name": "settlement_method",
           "ordinal": 3,
-          "type_info": "Numeric"
+          "type_info": "Varchar"
         },
         {
           "name": "settlement_amount",
@@ -54,7 +42,7 @@
       "nullable": [
         false,
         false,
-        true,
+        false,
         false,
         false,
         false,
@@ -64,7 +52,19 @@
         "Left": []
       }
     },
-    "query": "\n            SELECT id, direction, memo, amount_in_usd_cents, settlement_amount, settlement_currency, created_at\n            FROM galoy_transactions\n            WHERE is_paired = false AND amount_in_usd_cents != 0 ORDER BY created_at FOR UPDATE\n         "
+    "query": "\n            SELECT id, direction, amount_in_usd_cents, settlement_method, settlement_amount, settlement_currency, created_at\n            FROM galoy_transactions\n            WHERE is_paired = false AND amount_in_usd_cents != 0 ORDER BY created_at FOR UPDATE\n         "
+  },
+  "21fff44c3d9afbeb410e20503d5503ed369d2e1e973d7240ea7e6db64d15af9d": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "TextArray"
+        ]
+      }
+    },
+    "query": "UPDATE galoy_transactions SET is_paired = 'true' WHERE id = ANY($1)"
   },
   "2b868fd5a78978ec8bc3bcd79008f831a139e070f994b0b8bfe4e8a3dd3105f7": {
     "describe": {
@@ -83,6 +83,51 @@
       }
     },
     "query": "SELECT cursor FROM galoy_transactions ORDER BY created_at DESC LIMIT 1"
+  },
+  "4b5942fb896f349b40cd0f0b61b5f709f619b71ab2d02291d29c2ebdd98727bd": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Int4"
+        },
+        {
+          "name": "btc_id",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "usd_id",
+          "ordinal": 2,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        null,
+        null,
+        null
+      ],
+      "parameters": {
+        "Left": [
+          "TextArray"
+        ]
+      }
+    },
+    "query": "SELECT id, external_ref->>'btc_tx_id' AS btc_id, external_ref->>'usd_tx_id' AS usd_id FROM user_trades WHERE external_ref->>'btc_tx_id' = ANY($1)\n             UNION\n             SELECT id, external_ref->>'btc_tx_id' AS btc_id, external_ref->>'usd_tx_id' AS usd_id FROM user_trades WHERE external_ref->>'usd_tx_id' = ANY($1)"
+  },
+  "c0a3dad5c21faee2e7ee480ceeba54924c70f5d53c344cfcf6ac09d759016976": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int4Array"
+        ]
+      }
+    },
+    "query": "UPDATE user_trades SET correction_ledger_tx_id = $1 WHERE id = ANY($2) AND correction_ledger_tx_id IS NULL"
   },
   "ecda7feba70249cfa67e14e09d73daaac625dcbf4b307ae664f26b9f5d0eef2d": {
     "describe": {
@@ -153,5 +198,82 @@
       }
     },
     "query": "UPDATE user_trades\n               SET ledger_tx_id = $1\n               WHERE id = (\n                 SELECT id FROM user_trades WHERE ledger_tx_id IS NULL ORDER BY external_ref->>'timestamp' LIMIT 1\n               ) RETURNING id, buy_amount, buy_unit as \"buy_unit: UserTradeUnit\", sell_amount, sell_unit as \"sell_unit: UserTradeUnit\", external_ref"
+  },
+  "fee34cfbdb19294324dc4ceb3cc20fcf3bd61814cd8f1a680564ba14a14b2185": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Int4"
+        },
+        {
+          "name": "ledger_tx_id",
+          "ordinal": 1,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "buy_amount",
+          "ordinal": 2,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "buy_unit: UserTradeUnit",
+          "ordinal": 3,
+          "type_info": {
+            "Custom": {
+              "kind": {
+                "Enum": [
+                  "usd_cent",
+                  "satoshi"
+                ]
+              },
+              "name": "usertradeunit"
+            }
+          }
+        },
+        {
+          "name": "sell_amount",
+          "ordinal": 4,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "sell_unit: UserTradeUnit",
+          "ordinal": 5,
+          "type_info": {
+            "Custom": {
+              "kind": {
+                "Enum": [
+                  "usd_cent",
+                  "satoshi"
+                ]
+              },
+              "name": "usertradeunit"
+            }
+          }
+        },
+        {
+          "name": "external_ref",
+          "ordinal": 6,
+          "type_info": "Jsonb"
+        }
+      ],
+      "nullable": [
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "UPDATE user_trades\n               SET correction_ledger_tx_id = $1\n               WHERE id = (\n                 SELECT id FROM user_trades WHERE ledger_tx_id IS NOT NULL AND correction_ledger_tx_id = $2 ORDER BY external_ref->>'timestamp' LIMIT 1\n               ) RETURNING id, ledger_tx_id, buy_amount, buy_unit as \"buy_unit: UserTradeUnit\", sell_amount, sell_unit as \"sell_unit: UserTradeUnit\", external_ref"
   }
 }

--- a/user-trades/sqlx-data.json
+++ b/user-trades/sqlx-data.json
@@ -1,5 +1,71 @@
 {
   "db": "PostgreSQL",
+  "21fff44c3d9afbeb410e20503d5503ed369d2e1e973d7240ea7e6db64d15af9d": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "TextArray"
+        ]
+      }
+    },
+    "query": "UPDATE galoy_transactions SET is_paired = 'true' WHERE id = ANY($1)"
+  },
+  "2ab6719038a358bdeb8020ed6c84b8b8b79f1562b82987082e32f113d029ab9c": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "direction",
+          "ordinal": 1,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "memo",
+          "ordinal": 2,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "amount_in_usd_cents",
+          "ordinal": 3,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "settlement_amount",
+          "ordinal": 4,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "settlement_currency",
+          "ordinal": 5,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 6,
+          "type_info": "Timestamptz"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\n            SELECT id, direction, memo, amount_in_usd_cents, settlement_amount, settlement_currency, created_at\n            FROM galoy_transactions\n            WHERE is_paired = false AND amount_in_usd_cents != 0 ORDER BY created_at FOR UPDATE\n         "
+  },
   "2b868fd5a78978ec8bc3bcd79008f831a139e070f994b0b8bfe4e8a3dd3105f7": {
     "describe": {
       "columns": [
@@ -87,47 +153,5 @@
       }
     },
     "query": "UPDATE user_trades\n               SET ledger_tx_id = $1\n               WHERE id = (\n                 SELECT id FROM user_trades WHERE ledger_tx_id IS NULL ORDER BY external_ref->>'timestamp' LIMIT 1\n               ) RETURNING id, buy_amount, buy_unit as \"buy_unit: UserTradeUnit\", sell_amount, sell_unit as \"sell_unit: UserTradeUnit\", external_ref"
-  },
-  "fbeadad71170b3413e08ca82e3da340b4d6a0f5c6d7a963c08b590a568a714f5": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Varchar"
-        },
-        {
-          "name": "settlement_amount",
-          "ordinal": 1,
-          "type_info": "Numeric"
-        },
-        {
-          "name": "settlement_currency",
-          "ordinal": 2,
-          "type_info": "Varchar"
-        },
-        {
-          "name": "amount_in_usd_cents",
-          "ordinal": 3,
-          "type_info": "Numeric"
-        },
-        {
-          "name": "created_at",
-          "ordinal": 4,
-          "type_info": "Timestamptz"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Left": []
-      }
-    },
-    "query": "\n            SELECT id, settlement_amount, settlement_currency, amount_in_usd_cents, created_at\n            FROM galoy_transactions\n            WHERE is_paired = false AND amount_in_usd_cents != 0 ORDER BY created_at FOR UPDATE\n         "
   }
 }

--- a/user-trades/sqlx-data.json
+++ b/user-trades/sqlx-data.json
@@ -1,59 +1,5 @@
 {
   "db": "PostgreSQL",
-  "05219fc1273ea7a34b9b582be067d1ba065ce4e7cc4bd1b5af7f520bb36aff44": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Varchar"
-        },
-        {
-          "name": "direction",
-          "ordinal": 1,
-          "type_info": "Varchar"
-        },
-        {
-          "name": "amount_in_usd_cents",
-          "ordinal": 2,
-          "type_info": "Numeric"
-        },
-        {
-          "name": "settlement_method",
-          "ordinal": 3,
-          "type_info": "Varchar"
-        },
-        {
-          "name": "settlement_amount",
-          "ordinal": 4,
-          "type_info": "Numeric"
-        },
-        {
-          "name": "settlement_currency",
-          "ordinal": 5,
-          "type_info": "Varchar"
-        },
-        {
-          "name": "created_at",
-          "ordinal": 6,
-          "type_info": "Timestamptz"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Left": []
-      }
-    },
-    "query": "\n            SELECT id, direction, amount_in_usd_cents, settlement_method, settlement_amount, settlement_currency, created_at\n            FROM galoy_transactions\n            WHERE is_paired = false AND amount_in_usd_cents != 0 ORDER BY created_at FOR UPDATE\n         "
-  },
   "21fff44c3d9afbeb410e20503d5503ed369d2e1e973d7240ea7e6db64d15af9d": {
     "describe": {
       "columns": [],
@@ -84,7 +30,80 @@
     },
     "query": "SELECT cursor FROM galoy_transactions ORDER BY created_at DESC LIMIT 1"
   },
-  "4b5942fb896f349b40cd0f0b61b5f709f619b71ab2d02291d29c2ebdd98727bd": {
+  "826a2e93ff9e145528eaafb810f5c8028a099f205369d4e59766f46c6a0d7500": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "direction",
+          "ordinal": 1,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "amount_in_usd_cents",
+          "ordinal": 2,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "memo",
+          "ordinal": 3,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "settlement_method",
+          "ordinal": 4,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "settlement_amount",
+          "ordinal": 5,
+          "type_info": "Numeric"
+        },
+        {
+          "name": "settlement_currency",
+          "ordinal": 6,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 7,
+          "type_info": "Timestamptz"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\n            SELECT id, direction, amount_in_usd_cents, memo, settlement_method, settlement_amount, settlement_currency, created_at\n            FROM galoy_transactions\n            WHERE is_paired = false AND amount_in_usd_cents != 0 ORDER BY created_at FOR UPDATE\n         "
+  },
+  "c0a3dad5c21faee2e7ee480ceeba54924c70f5d53c344cfcf6ac09d759016976": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Int4Array"
+        ]
+      }
+    },
+    "query": "UPDATE user_trades SET correction_ledger_tx_id = $1 WHERE id = ANY($2) AND correction_ledger_tx_id IS NULL"
+  },
+  "cb456cade246ef96b3f03e01d373e081166e03d1ec2914606b975d33273c195c": {
     "describe": {
       "columns": [
         {
@@ -114,20 +133,7 @@
         ]
       }
     },
-    "query": "SELECT id, external_ref->>'btc_tx_id' AS btc_id, external_ref->>'usd_tx_id' AS usd_id FROM user_trades WHERE external_ref->>'btc_tx_id' = ANY($1)\n             UNION\n             SELECT id, external_ref->>'btc_tx_id' AS btc_id, external_ref->>'usd_tx_id' AS usd_id FROM user_trades WHERE external_ref->>'usd_tx_id' = ANY($1)"
-  },
-  "c0a3dad5c21faee2e7ee480ceeba54924c70f5d53c344cfcf6ac09d759016976": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Int4Array"
-        ]
-      }
-    },
-    "query": "UPDATE user_trades SET correction_ledger_tx_id = $1 WHERE id = ANY($2) AND correction_ledger_tx_id IS NULL"
+    "query": "SELECT id, external_ref->>'btc_tx_id' AS btc_id, external_ref->>'usd_tx_id' AS usd_id FROM user_trades WHERE external_ref->>'btc_tx_id' = ANY($1) AND correction_ledger_tx_id IS NULL\n             UNION\n             SELECT id, external_ref->>'btc_tx_id' AS btc_id, external_ref->>'usd_tx_id' AS usd_id FROM user_trades WHERE external_ref->>'usd_tx_id' = ANY($1) AND correction_ledger_tx_id IS NULL"
   },
   "ecda7feba70249cfa67e14e09d73daaac625dcbf4b307ae664f26b9f5d0eef2d": {
     "describe": {

--- a/user-trades/src/galoy_transactions/mod.rs
+++ b/user-trades/src/galoy_transactions/mod.rs
@@ -13,6 +13,7 @@ pub struct UnpairedTransaction {
     pub settlement_currency: SettlementCurrency,
     pub direction: String,
     pub settlement_method: String,
+    pub memo: Option<String>,
     pub amount_in_usd_cents: Decimal,
     pub created_at: chrono::DateTime<chrono::Utc>,
 }
@@ -95,7 +96,7 @@ impl GaloyTransactions {
         let mut tx = self.pool.begin().await?;
         let res = sqlx::query!(
             "
-            SELECT id, direction, amount_in_usd_cents, settlement_method, settlement_amount, settlement_currency, created_at
+            SELECT id, direction, amount_in_usd_cents, memo, settlement_method, settlement_amount, settlement_currency, created_at
             FROM galoy_transactions
             WHERE is_paired = false AND amount_in_usd_cents != 0 ORDER BY created_at FOR UPDATE
          "
@@ -113,6 +114,7 @@ impl GaloyTransactions {
                         .parse()
                         .expect("Couldn't parse settlement currency"),
                     direction: res.direction,
+                    memo: res.memo,
                     amount_in_usd_cents: res.amount_in_usd_cents,
                     settlement_method: res.settlement_method,
                     created_at: res.created_at,

--- a/user-trades/src/job/poll_galoy_transactions.rs
+++ b/user-trades/src/job/poll_galoy_transactions.rs
@@ -84,7 +84,7 @@ fn find_trades_needing_correction(
             lookup.btc_to_usd.remove(&trade.external_ref.btc_tx_id),
         ) {
             (None, None) => filtered_trades.push(trade),
-            (Some((btc_id, _)), Some((usd_id, _))) => {
+            (Some((usd_id, _)), Some((btc_id, _))) => {
                 if usd_id != btc_id {
                     filtered_trades.push(trade);
                     bad_trades.push(usd_id);
@@ -271,7 +271,7 @@ fn is_pair(tx1: &UnpairedTransaction, tx2: &UnpairedTransaction) -> bool {
         && tx1.settlement_method == tx2.settlement_method
     {
         return match (tx1.memo.as_ref(), tx2.memo.as_ref()) {
-            (Some(memo), _) | (_, Some(memo)) if memo.starts_with("JournalId") => {
+            (Some(memo), _) | (_, Some(memo)) if memo.starts_with("JournalId:") => {
                 tx1.memo == tx2.memo
             }
             _ => {

--- a/user-trades/src/user_trades/mod.rs
+++ b/user-trades/src/user_trades/mod.rs
@@ -50,6 +50,7 @@ pub struct NewUserTrade {
     pub external_ref: ExternalRef,
 }
 
+#[derive(Debug)]
 pub struct PairedTradesLookup {
     pub usd_to_btc: HashMap<String, (i32, String)>,
     pub btc_to_usd: HashMap<String, (i32, String)>,
@@ -125,9 +126,9 @@ impl UserTrades {
         ids: Vec<String>,
     ) -> Result<PairedTradesLookup, UserTradesError> {
         let rows = sqlx::query!(
-            "SELECT id, external_ref->>'btc_tx_id' AS btc_id, external_ref->>'usd_tx_id' AS usd_id FROM user_trades WHERE external_ref->>'btc_tx_id' = ANY($1)
+            "SELECT id, external_ref->>'btc_tx_id' AS btc_id, external_ref->>'usd_tx_id' AS usd_id FROM user_trades WHERE external_ref->>'btc_tx_id' = ANY($1) AND correction_ledger_tx_id IS NULL
              UNION
-             SELECT id, external_ref->>'btc_tx_id' AS btc_id, external_ref->>'usd_tx_id' AS usd_id FROM user_trades WHERE external_ref->>'usd_tx_id' = ANY($1)",
+             SELECT id, external_ref->>'btc_tx_id' AS btc_id, external_ref->>'usd_tx_id' AS usd_id FROM user_trades WHERE external_ref->>'usd_tx_id' = ANY($1) AND correction_ledger_tx_id IS NULL",
             &ids[..]
         ).fetch_all(&mut *tx)
             .await?;


### PR DESCRIPTION
This fix is related to a bug in galoy backend that is fixed as of https://github.com/GaloyMoney/galoy/releases/tag/0.5.178 and embedded in https://github.com/GaloyMoney/charts/releases/tag/galoy-v0.9.6.
Don't upgrade to this version of stablesats prior to rollout of those versions.