### PR TITLE
fix: funding balance buffer exceeded withdraw

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -13,7 +13,7 @@ In its current implementation, `stablesats` is coupled to and dependent on the [
 ## Dependencies
 Last tested with the following tools and application:
 ### Tools
-- Rust Compliler
+- Rust Compiler
 ```
 $ rustc --version
 rustc 1.63.0 (4b91a6ea7 2022-08-08)

--- a/hedging/src/okex/funding_adjustment.rs
+++ b/hedging/src/okex/funding_adjustment.rs
@@ -172,7 +172,11 @@ impl FundingAdjustment {
                 abs_exposure_in_btc / self.config.low_safebound_ratio_leverage;
             let transfer_size_in_btc = floor_btc(total_collateral_in_btc - new_collateral_in_btc);
 
-            calculate_transfer_out_withdraw(
+            calculate_transfer_out(transfer_size_in_btc)
+        } else if funding_btc_total_balance > self.config.minimum_funding_balance_btc {
+            let transfer_size_in_btc = Decimal::ZERO;
+
+            calculate_withdraw(
                 funding_btc_total_balance,
                 transfer_size_in_btc,
                 self.config.minimum_funding_balance_btc,
@@ -215,26 +219,6 @@ fn calculate_transfer_in_deposit(
         OkexFundingAdjustment::TransferFundingToTrading(internal_amount)
     } else if !external_amount.is_zero() {
         OkexFundingAdjustment::OnchainDeposit(external_amount)
-    } else {
-        OkexFundingAdjustment::DoNothing
-    }
-}
-
-fn calculate_transfer_out_withdraw(
-    funding_btc_total_balance: Decimal,
-    amount_in_btc: Decimal,
-    minimum_funding_balance_btc: Decimal,
-) -> OkexFundingAdjustment {
-    let internal_amount = amount_in_btc;
-    let external_amount = std::cmp::max(
-        Decimal::ZERO,
-        amount_in_btc + funding_btc_total_balance - minimum_funding_balance_btc,
-    );
-
-    if !internal_amount.is_zero() {
-        OkexFundingAdjustment::TransferTradingToFunding(internal_amount)
-    } else if !external_amount.is_zero() {
-        OkexFundingAdjustment::OnchainWithdraw(external_amount)
     } else {
         OkexFundingAdjustment::DoNothing
     }

--- a/hedging/src/okex/funding_adjustment.rs
+++ b/hedging/src/okex/funding_adjustment.rs
@@ -150,7 +150,7 @@ impl FundingAdjustment {
             calculate_withdraw(
                 funding_btc_total_balance,
                 transfer_size_in_btc,
-                self.config.minimum_funding_balance_btc,
+                Decimal::ZERO,
             )
         } else if abs_liability_in_cents > self.hedging_config.minimum_liability_threshold_cents
             && abs_liability_in_btc
@@ -452,11 +452,8 @@ mod tests {
         let funding_btc_total_balance: Decimal = dec!(2_000);
         let btc_price: Decimal = dec!(1);
         let expected_total: Decimal = floor_btc(total_collateral);
-        let (_, expected_external) = split_withdraw(
-            funding_btc_total_balance,
-            expected_total,
-            funding_adjustment.config.minimum_funding_balance_btc,
-        );
+        let (_, expected_external) =
+            split_withdraw(funding_btc_total_balance, expected_total, Decimal::ZERO);
         let adjustment = funding_adjustment.determine_action(
             liability,
             exposure,

--- a/hedging/src/okex/job/adjust_funding.rs
+++ b/hedging/src/okex/job/adjust_funding.rs
@@ -71,10 +71,6 @@ pub(super) async fn execute(
     );
     span.record("action", &tracing::field::display(&action));
 
-    if okex.is_simulated() {
-        return Ok(());
-    }
-
     let fees = okex.get_onchain_fees().await?;
     span.record("onchain_fees", &tracing::field::display(&fees));
 
@@ -133,6 +129,10 @@ pub(super) async fn execute(
                     }
                 }
                 OkexFundingAdjustment::OnchainDeposit(amount) => {
+                    if okex.is_simulated() {
+                        return Ok(());
+                    }
+
                     let deposit_address = okex.get_funding_deposit_address().await?.value;
                     let reservation = TransferReservation {
                         shared: &shared,
@@ -157,6 +157,10 @@ pub(super) async fn execute(
                     }
                 }
                 OkexFundingAdjustment::OnchainWithdraw(amount) => {
+                    if okex.is_simulated() {
+                        return Ok(());
+                    }
+
                     let deposit_address = galoy.onchain_address().await?.address;
                     let reservation = TransferReservation {
                         shared: &shared,

--- a/okex-client/src/client/mod.rs
+++ b/okex-client/src/client/mod.rs
@@ -171,16 +171,25 @@ impl OkexClient {
             .send()
             .await?;
 
-        let fees_data = Self::extract_response_data::<OnchainFeesData>(response).await?;
-
-        Ok(OnchainFees {
-            ccy: fees_data.ccy,
-            chain: fees_data.chain,
-            min_fee: std::cmp::min(fees_data.min_fee, OKEX_MINIMUM_WITHDRAWAL_FEE),
-            max_fee: std::cmp::min(fees_data.max_fee, OKEX_MAXIMUM_WITHDRAWAL_FEE),
-            min_withdraw: std::cmp::min(fees_data.min_wd, OKEX_MINIMUM_WITHDRAWAL_AMOUNT),
-            max_withdraw: std::cmp::min(fees_data.max_wd, OKEX_MAXIMUM_WITHDRAWAL_AMOUNT),
-        })
+        let fees_data_resp = Self::extract_response_data::<OnchainFeesData>(response).await;
+        match fees_data_resp {
+            Ok(fees_data) => Ok(OnchainFees {
+                ccy: fees_data.ccy,
+                chain: fees_data.chain,
+                min_fee: std::cmp::min(fees_data.min_fee, OKEX_MINIMUM_WITHDRAWAL_FEE),
+                max_fee: std::cmp::min(fees_data.max_fee, OKEX_MAXIMUM_WITHDRAWAL_FEE),
+                min_withdraw: std::cmp::min(fees_data.min_wd, OKEX_MINIMUM_WITHDRAWAL_AMOUNT),
+                max_withdraw: std::cmp::min(fees_data.max_wd, OKEX_MAXIMUM_WITHDRAWAL_AMOUNT),
+            }),
+            _ => Ok(OnchainFees {
+                ccy: "BTC".to_string(),
+                chain: "BTC-Bitcoin".to_string(),
+                min_fee: OKEX_MINIMUM_WITHDRAWAL_FEE,
+                max_fee: OKEX_MAXIMUM_WITHDRAWAL_FEE,
+                min_withdraw: OKEX_MINIMUM_WITHDRAWAL_AMOUNT,
+                max_withdraw: OKEX_MAXIMUM_WITHDRAWAL_AMOUNT,
+            }),
+        }
     }
 
     #[instrument(name = "okex_client.transfer_funding_to_trading", skip(self), err)]


### PR DESCRIPTION
The Counterparty Risk Avoidance condition, when Exposure Ratio is low,
only deals with trading account balances so only a transfer is initiated,
the withdrawal part has to be done subsequently.
This adds the new condition and withdrawal and simplifies the original condition to a transfer.
Resolving this issue: #341 