### PR TITLE
fix: okx deposit idempotency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,7 @@ dependencies = [
  "prost",
  "prost-wkt-types",
  "protobuf-src",
+ "rand",
  "rust_decimal",
  "rust_decimal_macros",
  "rusty-money",

--- a/bria-client/Cargo.toml
+++ b/bria-client/Cargo.toml
@@ -39,3 +39,4 @@ tonic-build = { version = "0.8", features = ["prost"] }
 
 [dev-dependencies]
 anyhow = "1.0.70"
+rand = { workspace = true }

--- a/bria-client/src/client.rs
+++ b/bria-client/src/client.rs
@@ -90,6 +90,7 @@ impl BriaClient {
         &mut self,
         destination: String,
         satoshis: rust_decimal::Decimal,
+        external_id: String,
     ) -> Result<String, BriaClientError> {
         use rust_decimal::prelude::ToPrimitive;
 
@@ -109,7 +110,7 @@ impl BriaClient {
                 .abs()
                 .to_u64()
                 .ok_or(BriaClientError::CouldNotConvertSatoshisToU64)?,
-            external_id: None,
+            external_id: Some(external_id),
             metadata: metadata.map(serde_json::from_value).transpose()?,
         });
 

--- a/bria-client/tests/bria_client.rs
+++ b/bria-client/tests/bria_client.rs
@@ -36,7 +36,11 @@ async fn send_onchain_payment() -> anyhow::Result<()> {
     let destination = "bcrt1q5cwegu66cf344du3ffrvnwjz9u246xlydqezsa".to_string();
     let satoshis = rust_decimal::Decimal::from(5000);
 
-    let id = client.send_onchain_payment(destination, satoshis).await?;
+    use rand::distributions::{Alphanumeric, DistString};
+    let external_id = Alphanumeric.sample_string(&mut rand::thread_rng(), 32);
+    let id = client
+        .send_onchain_payment(destination, satoshis, external_id)
+        .await?;
     assert!(!id.is_empty());
 
     Ok(())

--- a/hedging/src/okex/job/adjust_funding.rs
+++ b/hedging/src/okex/job/adjust_funding.rs
@@ -145,15 +145,16 @@ pub(super) async fn execute(
                     if let Some(client_id) =
                         okex_transfers.reserve_transfer_slot(reservation).await?
                     {
-                        span.record(
-                            "client_transfer_id",
-                            &tracing::field::display(String::from(client_id)),
-                        );
+                        let client_transfer_id = String::from(client_id.clone());
+                        span.record("client_transfer_id", &client_transfer_id);
 
                         let amount_in_sats = amount * SATS_PER_BTC;
-                        let _ = bria
-                            .send_onchain_payment(deposit_address, amount_in_sats)
-                            .await?;
+                        bria.send_onchain_payment(
+                            deposit_address,
+                            amount_in_sats,
+                            client_transfer_id,
+                        )
+                        .await?;
                     }
                 }
                 OkexFundingAdjustment::OnchainWithdraw(amount) => {


### PR DESCRIPTION
Deposits to okx get identified in a specific state.
State "1" are not yet available for withdraw and thus should still remain in state 'pending' otherwise multiple deposits will be
initiated.